### PR TITLE
Create an async package `aio` and reimplement tests from trunk

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ docs/simple_salesforce*.rst
 docs/modules.rst
 .vscode
 venv
+htmlcov/

--- a/setup.py
+++ b/setup.py
@@ -27,13 +27,17 @@ setup(
     long_description_content_type='text/x-rst',
     install_requires=[
         'requests>=2.22.0',
-        'httpx>=0.18.2,<1.0'
         'authlib'
     ],
+    extras_require={
+        "async": ['httpx>=0.18.2,<1.0', 'aiofiles>=0.7.0']
+    },
     tests_require=[
         'nose>=1.3.0',
         'pytz>=2014.1.1',
         'responses>=0.5.1',
+        'pytest',
+        'pytest-asyncio-0.15.1'
     ],
     test_suite='nose.collector',
     keywords=about['__keywords__'],

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ setup(
     long_description_content_type='text/x-rst',
     install_requires=[
         'requests>=2.22.0',
+        'httpx>=0.18.2,<1.0'
         'authlib'
     ],
     tests_require=[

--- a/simple_salesforce/aio/__init__.py
+++ b/simple_salesforce/aio/__init__.py
@@ -1,31 +1,11 @@
 """Simple-Salesforce Asyncio Package"""
 # flake8: noqa
 
-from .api import build_async_salesforce_client, AsyncSalesforce, SFType
-from .bulk import SFBulkHandler
-from .login import SalesforceLogin
+from .api import build_async_salesforce_client, AsyncSalesforce, AsyncSFType
+from .bulk import AsyncSFBulkHandler
+from .login import AsyncSalesforceLogin
 
 # TODO
-# $ rg -c requests
-# login.py:4
-# api.py:19
-# util.py:1
-# bulk.py:6
-# tests/test_api.py:38
-# tests/test_bulk.py:11
-# tests/test_login.py:6
-# api.py:40
-# util.py:2
-# messages.py:4
-# login.py:14
-# bulk.py:19
-# metadata.py:12
-# tests/test_api.py:83
-# tests/test_login.py:26
-# tests/test_util.py:3
-# tests/test_bulk.py:28
-# tests/__init__.py:2
-
 # import asyncio
 # from simple_salesforce.aio import *
 # import os

--- a/simple_salesforce/aio/__init__.py
+++ b/simple_salesforce/aio/__init__.py
@@ -4,16 +4,3 @@
 from .api import build_async_salesforce_client, AsyncSalesforce, AsyncSFType
 from .bulk import AsyncSFBulkHandler
 from .login import AsyncSalesforceLogin
-
-# TODO
-# import asyncio
-# from simple_salesforce.aio import *
-# import os
-# loop = asyncio.get_event_loop()
-# username = os.environ["DIRECT_APP_SF_CLIENT_USERNAME"]
-# consumer_key = os.environ["DIRECT_APP_SF_CLIENT_CONSUMER_KEY"]
-# sf_priv_keyfile = os.environ["DIRECT_APP_SF_CLIENT_PRIVATE_KEY"]
-# env = {'domain': "test"}
-# client = loop.run_until_complete(build_async_salesforce_client(
-#     username=username, consumer_key=consumer_key,privatekey_file=sf_priv_keyfile, domain="test")
-# )

--- a/simple_salesforce/aio/__init__.py
+++ b/simple_salesforce/aio/__init__.py
@@ -1,0 +1,39 @@
+"""Simple-Salesforce Asyncio Package"""
+# flake8: noqa
+
+from .api import build_async_salesforce_client, AsyncSalesforce, SFType
+from .bulk import SFBulkHandler
+from .login import SalesforceLogin
+
+# TODO
+# $ rg -c requests
+# login.py:4
+# api.py:19
+# util.py:1
+# bulk.py:6
+# tests/test_api.py:38
+# tests/test_bulk.py:11
+# tests/test_login.py:6
+# api.py:40
+# util.py:2
+# messages.py:4
+# login.py:14
+# bulk.py:19
+# metadata.py:12
+# tests/test_api.py:83
+# tests/test_login.py:26
+# tests/test_util.py:3
+# tests/test_bulk.py:28
+# tests/__init__.py:2
+
+# import asyncio
+# from simple_salesforce.aio import *
+# import os
+# loop = asyncio.get_event_loop()
+# username = os.environ["DIRECT_APP_SF_CLIENT_USERNAME"]
+# consumer_key = os.environ["DIRECT_APP_SF_CLIENT_CONSUMER_KEY"]
+# sf_priv_keyfile = os.environ["DIRECT_APP_SF_CLIENT_PRIVATE_KEY"]
+# env = {'domain': "test"}
+# client = loop.run_until_complete(build_async_salesforce_client(
+#     username=username, consumer_key=consumer_key,privatekey_file=sf_priv_keyfile, domain="test")
+# )

--- a/simple_salesforce/aio/aio_util.py
+++ b/simple_salesforce/aio/aio_util.py
@@ -1,0 +1,25 @@
+"""Utility functions for simple-salesforce async calls"""
+import httpx
+
+from simple_salesforce.util import exception_handler
+
+
+async def call_salesforce(
+    url=None, method=None, async_client=None, headers=None, **kwargs
+):
+    """Utility method for performing HTTP call to Salesforce.
+
+    Returns a `requests.result` object.
+    """
+    if not async_client:
+        async_client = httpx.AsyncClient()
+
+    additional_headers = kwargs.pop('additional_headers', dict())
+    headers.update(additional_headers or dict())
+    async with async_client as client:
+        result = await client.request(method, url, headers=headers, **kwargs)
+
+    if result.status_code >= 300:
+        exception_handler(result)
+
+    return result

--- a/simple_salesforce/aio/aio_util.py
+++ b/simple_salesforce/aio/aio_util.py
@@ -14,11 +14,11 @@ async def call_salesforce(
     if not async_client:
         async_client = httpx.AsyncClient()
 
+    headers = headers or dict()
     additional_headers = kwargs.pop('additional_headers', dict())
     headers.update(additional_headers or dict())
     async with async_client as client:
         result = await client.request(method, url, headers=headers, **kwargs)
-
     if result.status_code >= 300:
         exception_handler(result)
 

--- a/simple_salesforce/aio/aio_util.py
+++ b/simple_salesforce/aio/aio_util.py
@@ -1,15 +1,21 @@
 """Utility functions for simple-salesforce async calls"""
+from typing import Dict, Optional
+
 import httpx
 
 from simple_salesforce.util import exception_handler
 
 
 async def call_salesforce(
-    url=None, method=None, async_client=None, headers=None, **kwargs
+    url: str = "",
+    method: str = "GET",
+    async_client: Optional[httpx.AsyncClient] = None,
+    headers: Optional[Dict] = None,
+    **kwargs
 ):
     """Utility method for performing HTTP call to Salesforce.
 
-    Returns a `requests.result` object.
+    Returns a `httpx.Response` object.
     """
     if not async_client:
         async_client = httpx.AsyncClient()

--- a/simple_salesforce/aio/api.py
+++ b/simple_salesforce/aio/api.py
@@ -92,6 +92,9 @@ async def build_async_salesforce_client(
     """
     if domain is None:
         domain = 'login'
+    if session is None:
+        session = httpx.AsyncClient(proxies=proxies)
+
     instance_kwargs = {
         "version": version,
         "proxies": proxies,

--- a/simple_salesforce/aio/api.py
+++ b/simple_salesforce/aio/api.py
@@ -1,0 +1,1007 @@
+"""Core classes and exceptions for Simple-Salesforce"""
+import json
+import logging
+import re
+from collections import OrderedDict, namedtuple
+from urllib.parse import urljoin, urlparse
+
+import httpx
+
+from simple_salesforce.api import DEFAULT_API_VERSION
+from simple_salesforce.exceptions import SalesforceGeneralError
+from simple_salesforce.util import date_to_iso8601, exception_handler
+from .bulk import SFBulkHandler
+from .login import SalesforceLogin
+from .metadata import SfdcMetadataApi
+
+# pylint: disable=invalid-name
+logger = logging.getLogger(__name__)
+
+Usage = namedtuple('Usage', 'used total')
+PerAppUsage = namedtuple('PerAppUsage', 'used total name')
+
+
+async def build_async_salesforce_client(
+    username=None,
+    password=None,
+    security_token=None,
+    session_id=None,
+    instance=None,
+    instance_url=None,
+    organizationId=None,
+    version=DEFAULT_API_VERSION,
+    proxies=None,
+    session=None,
+    client_id=None,
+    domain=None,
+    consumer_key=None,
+    privatekey_file=None,
+    privatekey=None,
+):
+    """
+    Reasons for this builder function:
+
+        - Async code is not allowed in __init__ method.
+        - Also, the original Salesforce client did not store
+        username/password on the instance
+
+    Thus, this helper functions constructs an instance
+    and issues an *async* login call without storing auth parameters
+    in memory. This function has same kwargs as the original
+    `Salesforce` client class.
+
+    Available kwargs
+
+    Password Authentication:
+
+    * username -- the Salesforce username to use for authentication
+    * password -- the password for the username
+    * security_token -- the security token for the username
+    * domain -- The domain to using for connecting to Salesforce. Use
+                common domains, such as 'login' or 'test', or
+                Salesforce My domain. If not used, will default to
+                'login'.
+
+    OAuth 2.0 JWT Bearer Token Authentication:
+
+    * consumer_key -- the consumer key generated for the user
+
+    Then either
+    * privatekey_file -- the path to the private key file used
+                            for signing the JWT token
+    OR
+    * privatekey -- the private key to use
+                        for signing the JWT token
+
+    Direct Session and Instance Access:
+
+    * session_id -- Access token for this session
+
+    Then either
+    * instance -- Domain of your Salesforce instance, i.e.
+        `na1.salesforce.com`
+    OR
+    * instance_url -- Full URL of your instance i.e.
+        `https://na1.salesforce.com
+
+    Universal Kwargs:
+    * version -- the version of the Salesforce API to use, for example
+                    `29.0`
+    * proxies -- the optional map of scheme to proxy server (note: httpx style!)
+    * session -- Custom httpx session (AsyncClient), created in calling code. This
+                enables the use of httpx AsyncClient features not otherwise
+                exposed by simple_salesforce.
+    """
+    if domain is None:
+        domain = 'login'
+    instance_kwargs = {
+        "version": version,
+        "proxies": proxies,
+        "session": session,
+        "domain": domain
+    }
+
+    # Determine if the user wants to use our username/password auth or pass
+    # in their own information
+    if all(arg is not None for arg in (
+            username, password, security_token)):
+        instance_kwargs["auth_type"] = "password"
+
+        # Pass along the username/password to our login helper
+        session_id, sf_instance = await SalesforceLogin(
+            session=session,
+            username=username,
+            password=password,
+            security_token=security_token,
+            sf_version=version,
+            proxies=proxies,
+            client_id=client_id,
+            domain=domain)
+        instance_kwargs["session_id"] = session_id
+        instance_kwargs["sf_instance"] = sf_instance
+
+    elif all(arg is not None for arg in (
+            session_id, instance or instance_url)):
+        instance_kwargs["auth_type"] = "direct"
+        instance_kwargs["session_id"] = session_id
+
+        # If the user provides the full url (as returned by the OAuth
+        # interface for example) extract the hostname (which we rely on)
+        if instance_url is not None:
+            instance_kwargs["sf_instance"] = urlparse(instance_url).hostname
+        else:
+            instance_kwargs["sf_instance"] = instance
+
+    elif all(arg is not None for arg in (
+            username, password, organizationId)):
+        instance_kwargs["auth_type"] = 'ipfilter'
+
+        # Pass along the username/password to our login helper
+        session_id, sf_instance = await SalesforceLogin(
+            session=session,
+            username=username,
+            password=password,
+            organizationId=organizationId,
+            sf_version=version,
+            proxies=proxies,
+            client_id=client_id,
+            domain=domain)
+        instance_kwargs["session_id"] = session_id
+        instance_kwargs["sf_instance"] = sf_instance
+
+    elif all(arg is not None for arg in (
+            username, consumer_key, privatekey_file or privatekey)):
+        instance_kwargs["auth_type"] = "jwt-bearer"
+
+        # Pass along the username/password to our login helper
+        session_id, sf_instance = await SalesforceLogin(
+            session=session,
+            username=username,
+            consumer_key=consumer_key,
+            privatekey_file=privatekey_file,
+            privatekey=privatekey,
+            proxies=proxies,
+            domain=domain)
+        instance_kwargs["session_id"] = session_id
+        instance_kwargs["sf_instance"] = sf_instance
+
+    else:
+        raise TypeError(
+            'You must provide login information or an instance and token'
+        )
+    return AsyncSalesforce(**instance_kwargs)
+
+
+# pylint: disable=too-many-instance-attributes
+class AsyncSalesforce:
+    """Salesforce Instance
+
+    An instance of AsyncSalesforce is a handy way to wrap a Salesforce session
+    for easy use of the Salesforce REST API. All http network calls are async.
+    """
+
+    # pylint: disable=too-many-arguments,too-many-locals,too-many-branches
+    def __init__(
+        self,
+        version=DEFAULT_API_VERSION,
+        proxies=None,
+        session=None,
+        domain=None,
+        auth_type=None,
+        session_id=None,
+        sf_instance=None,
+    ):
+
+        """Initialize the instance with the given parameters.
+
+        Universal Kwargs:
+
+        * domain -- The domain to using for connecting to Salesforce. Use
+                    common domains, such as 'login' or 'test', or
+                    Salesforce My domain. If not used, will default to
+                    'login'.
+        * version -- the version of the Salesforce API to use, for example
+                     `29.0`
+        * proxies -- the optional map of scheme to proxy server (note: httpx style!)
+        * session -- Custom httpx session (AsyncClient), created in calling code. This
+                    enables the use of httpx AsyncClient features not otherwise
+                    exposed by simple_salesforce.
+        """
+        # Determine if the user passed in the optional version and/or
+        # domain kwargs
+        self.auth_type = auth_type
+        self.session_id = session_id
+        self.sf_instance = sf_instance
+        self.sf_version = version
+        self.domain = domain
+        self._session = session
+        self._proxies = proxies
+        # override custom session proxies dance
+        if proxies is not None and self._session:
+            self._session.proxies = self._proxies = proxies
+        elif proxies:
+            logger.warning(
+                'Proxies must be defined on custom session object, '
+                'ignoring proxies: %s', proxies
+            )
+
+        self.auth_site = ('https://{domain}.salesforce.com'
+                          .format(domain=self.domain))
+
+        self.headers = {
+            'Content-Type': 'application/json',
+            'Authorization': 'Bearer ' + self.session_id,
+            'X-PrettyPrint': '1'
+        }
+
+        self.base_url = ('https://{instance}/services/data/v{version}/'
+                         .format(instance=self.sf_instance,
+                                 version=self.sf_version))
+        self.apex_url = ('https://{instance}/services/apexrest/'
+                         .format(instance=self.sf_instance))
+        self.bulk_url = ('https://{instance}/services/async/{version}/'
+                         .format(instance=self.sf_instance,
+                                 version=self.sf_version))
+        self.metadata_url = ('https://{instance}/services/Soap/m/{version}/'
+                             .format(instance=self.sf_instance,
+                                     version=self.sf_version))
+        self.tooling_url = '{base_url}tooling/'.format(base_url=self.base_url)
+
+        self.api_usage = {}
+
+    @property
+    def session(self):
+        """
+        Returns an AsyncClient which can be used as an async context manager
+        """
+        if self._session:
+            return self._session
+        if self._proxies:
+            return httpx.AsyncClient(proxies=self._proxies)
+        return httpx.AsyncClient()
+
+    async def describe(self, **kwargs):
+        """Describes all available objects
+
+        Arguments:
+
+        * keyword arguments supported by requests.request (e.g. json, timeout)
+        """
+        url = self.base_url + "sobjects"
+        result = await self._call_salesforce('GET', url, name='describe', **kwargs)
+
+        json_result = result.json(object_pairs_hook=OrderedDict)
+        if len(json_result) == 0:
+            return None
+
+        return json_result
+
+    def is_sandbox(self):
+        """After connection returns is the organization in a sandbox"""
+        is_sandbox = None
+        if self.session_id:
+            is_sandbox = self.query_all("SELECT IsSandbox "
+                                        "FROM Organization LIMIT 1")
+            is_sandbox = is_sandbox.get('records', [{'IsSandbox': None}])[
+                0].get(
+                'IsSandbox')
+        return is_sandbox
+
+    # SObject Handler
+    def __getattr__(self, name):
+        """Returns an `SFType` instance for the given Salesforce object type
+        (given in `name`).
+
+        The magic part of the SalesforceAPI, this function translates
+        calls such as `salesforce_api_instance.Lead.metadata()` into fully
+        constituted `SFType` instances to make a nice Python API wrapper
+        for the REST API.
+
+        Arguments:
+
+        * name -- the name of a Salesforce object type, e.g. Lead or Contact
+        """
+
+        # fix to enable serialization
+        # (https://github.com/heroku/simple-salesforce/issues/60)
+        if name.startswith('__'):
+            return super().__getattr__(name)
+
+        if name == 'bulk':
+            # Deal with bulk API functions
+            return SFBulkHandler(self.session_id, self.bulk_url, self._proxies,
+                                 self._session)
+
+        return SFType(
+            name, self.session_id, self.sf_instance, sf_version=self.sf_version,
+            proxies=self._proxies, session=self._session)
+
+    # User utility methods
+    async def set_password(self, user, password):
+        """Sets the password of a user
+
+        salesforce dev documentation link:
+        https://www.salesforce.com/us/developer/docs/api_rest/Content
+        /dome_sobject_user_password.htm
+
+        Arguments:
+
+        * user: the userID of the user to set
+        * password: the new password
+        """
+
+        url = self.base_url + 'sobjects/User/%s/password' % user
+        params = {'NewPassword': password}
+
+        result = await self._call_salesforce(
+            'POST', url, data=json.dumps(params)
+        )
+
+        if result.status_code == 204:
+            return None
+
+        # salesforce return 204 No Content when the request is successful
+        if result.status_code != 200:
+            raise SalesforceGeneralError(url,
+                                         result.status_code,
+                                         'User',
+                                         result.content)
+        return result.json(object_pairs_hook=OrderedDict)
+
+    # Generic Rest Function
+    async def restful(self, path, params=None, method='GET', **kwargs):
+        """Allows you to make a direct REST call if you know the path
+
+        Arguments:
+
+        * path: The path of the request
+            Example: sobjects/User/ABC123/password'
+        * params: dict of parameters to pass to the path
+        * method: HTTP request method, default GET
+        * other arguments supported by requests.request (e.g. json, timeout)
+        """
+
+        url = self.base_url + path
+        result = await self._call_salesforce(
+            method, url, name=path, params=params, **kwargs
+        )
+
+        json_result = result.json(object_pairs_hook=OrderedDict)
+        if len(json_result) == 0:
+            return None
+
+        return json_result
+
+    # Search Functions
+    async def search(self, search):
+        """Returns the result of a Salesforce search as a dict decoded from
+        the Salesforce response JSON payload.
+
+        Arguments:
+
+        * search -- the fully formatted SOSL search string, e.g.
+                    `FIND {Waldo}`
+        """
+        url = self.base_url + 'search/'
+
+        # `requests` will correctly encode the query string passed as `params`
+        params = {'q': search}
+        result = await self._call_salesforce('GET', url, name='search', params=params)
+
+        json_result = result.json(object_pairs_hook=OrderedDict)
+        if len(json_result) == 0:
+            return None
+
+        return json_result
+
+    def quick_search(self, search):
+        """Returns the result of a Salesforce search as a dict decoded from
+        the Salesforce response JSON payload.
+
+        Arguments:
+
+        * search -- the non-SOSL search string, e.g. `Waldo`. This search
+                    string will be wrapped to read `FIND {Waldo}` before being
+                    sent to Salesforce
+        """
+        search_string = 'FIND {{{search_string}}}'.format(search_string=search)
+        return self.search(search_string)
+
+    async def limits(self, **kwargs):
+        """Return the result of a Salesforce request to list Organization
+        limits.
+        """
+        url = self.base_url + 'limits/'
+        result = await self._call_salesforce('GET', url, **kwargs)
+
+        if result.status_code != 200:
+            exception_handler(result)
+
+        return result.json(object_pairs_hook=OrderedDict)
+
+    # Query Handler
+    async def query(self, query, include_deleted=False, **kwargs):
+        """Return the result of a Salesforce SOQL query as a dict decoded from
+        the Salesforce response JSON payload.
+
+        Arguments:
+
+        * query -- the SOQL query to send to Salesforce, e.g.
+                   SELECT Id FROM Lead WHERE Email = "waldo@somewhere.com"
+        * include_deleted -- True if deleted records should be included
+        """
+        url = self.base_url + ('queryAll/' if include_deleted else 'query/')
+        params = {'q': query}
+        # `requests` will correctly encode the query string passed as `params`
+        result = await self._call_salesforce(
+            'GET', url, name='query', params=params, **kwargs
+        )
+
+        return result.json(object_pairs_hook=OrderedDict)
+
+    async def query_more(
+            self, next_records_identifier, identifier_is_url=False,
+            include_deleted=False, **kwargs):
+        """Retrieves more results from a query that returned more results
+        than the batch maximum. Returns a dict decoded from the Salesforce
+        response JSON payload.
+
+        Arguments:
+
+        * next_records_identifier -- either the Id of the next Salesforce
+                                     object in the result, or a URL to the
+                                     next record in the result.
+        * identifier_is_url -- True if `next_records_identifier` should be
+                               treated as a URL, False if
+                               `next_records_identifier` should be treated as
+                               an Id.
+        * include_deleted -- True if the `next_records_identifier` refers to a
+                             query that includes deleted records. Only used if
+                             `identifier_is_url` is False
+        """
+        if identifier_is_url:
+            # Don't use `self.base_url` here because the full URI is provided
+            url = ('https://{instance}{next_record_url}'
+                   .format(instance=self.sf_instance,
+                           next_record_url=next_records_identifier))
+        else:
+            endpoint = 'queryAll' if include_deleted else 'query'
+            url = self.base_url + '{query_endpoint}/{next_record_id}'
+            url = url.format(query_endpoint=endpoint,
+                             next_record_id=next_records_identifier)
+        result = await self._call_salesforce(
+            'GET', url, name='query_more', **kwargs
+        )
+
+        return result.json(object_pairs_hook=OrderedDict)
+
+    async def query_all_iter(self, query, include_deleted=False, **kwargs):
+        """This is a lazy alternative to `query_all` - it does not construct
+        the whole result set into one container, but returns objects from each
+        page it retrieves from the API.
+
+        Since `query_all` has always been eagerly executed, we reimplemented it
+        using `query_all_iter`, only materializing the returned iterator to
+        maintain backwards compatibility.
+
+        The one big difference from `query_all` (apart from being lazy) is that
+        we don't return a dictionary with `totalSize` and `done` here,
+        we only return the records in an iterator.
+
+        Arguments
+
+        * query -- the SOQL query to send to Salesforce, e.g.
+                   SELECT Id FROM Lead WHERE Email = "waldo@somewhere.com"
+        * include_deleted -- True if the query should include deleted records.
+        """
+
+        result = await self.query(
+            query, include_deleted=include_deleted, **kwargs
+        )
+        while True:
+            for record in result['records']:
+                yield record
+            # fetch next batch if we're not done else break out of loop
+            if not result['done']:
+                result = await self.query_more(
+                    result['nextRecordsUrl'], identifier_is_url=True
+                )
+            else:
+                return
+
+    async def query_all(self, query, include_deleted=False, **kwargs):
+        """Returns the full set of results for the `query`. This is a
+        convenience
+        wrapper around `query(...)` and `query_more(...)`.
+
+        The returned dict is the decoded JSON payload from the final call to
+        Salesforce, but with the `totalSize` field representing the full
+        number of results retrieved and the `records` list representing the
+        full list of records retrieved.
+
+        Arguments
+
+        * query -- the SOQL query to send to Salesforce, e.g.
+                   SELECT Id FROM Lead WHERE Email = "waldo@somewhere.com"
+        * include_deleted -- True if the query should include deleted records.
+        """
+
+        records = await self.query_all_iter(query, include_deleted=include_deleted,
+                                            **kwargs)
+        all_records = list(records)
+        return {
+            'records': all_records,
+            'totalSize': len(all_records),
+            'done': True,
+        }
+
+    async def toolingexecute(self, action, method='GET', data=None, **kwargs):
+        """Makes an HTTP request to an TOOLING REST endpoint
+
+        Arguments:
+
+        * action -- The REST endpoint for the request.
+        * method -- HTTP method for the request (default GET)
+        * data -- A dict of parameters to send in a POST / PUT request
+        * kwargs -- Additional kwargs to pass to `requests.request`
+        """
+        # If data is None, we should send an empty body, not "null", which is
+        # None in json.
+        json_data = json.dumps(data) if data is not None else None
+        result = await self._call_salesforce(
+            method,
+            self.tooling_url + action,
+            name="toolingexecute",
+            data=json_data, **kwargs
+        )
+        try:
+            response_content = result.json()
+        # pylint: disable=broad-except
+        except Exception:
+            response_content = result.text
+
+        return response_content
+
+    async def apexecute(self, action, method='GET', data=None, **kwargs):
+        """Makes an HTTP request to an APEX REST endpoint
+
+        Arguments:
+
+        * action -- The REST endpoint for the request.
+        * method -- HTTP method for the request (default GET)
+        * data -- A dict of parameters to send in a POST / PUT request
+        * kwargs -- Additional kwargs to pass to `requests.request`
+        """
+        # If data is None, we should send an empty body, not "null", which is
+        # None in json.
+        json_data = json.dumps(data) if data is not None else None
+        result = await self._call_salesforce(
+            method,
+            self.apex_url + action,
+            name="apexecute",
+            data=json_data, **kwargs
+        )
+        try:
+            response_content = result.json()
+        # pylint: disable=broad-except
+        except Exception:
+            response_content = result.text
+
+        return response_content
+
+    async def _call_salesforce(self, method, url, name="", **kwargs):
+        """Utility method for performing HTTP call to Salesforce.
+
+        Returns a `requests.result` object.
+        """
+        headers = self.headers.copy()
+        additional_headers = kwargs.pop('headers', dict())
+        headers.update(additional_headers)
+
+        async with self.session as client:
+            result = await client.request(
+                method, url, headers=headers, **kwargs
+            )
+
+        if result.status_code >= 300:
+            exception_handler(result, name=name)
+
+        sforce_limit_info = result.headers.get('Sforce-Limit-Info')
+        if sforce_limit_info:
+            self.api_usage = self.parse_api_usage(sforce_limit_info)
+
+        return result
+
+    @staticmethod
+    def parse_api_usage(sforce_limit_info):
+        """parse API usage and limits out of the Sforce-Limit-Info header
+
+        Arguments:
+
+        * sforce_limit_info: The value of response header 'Sforce-Limit-Info'
+            Example 1: 'api-usage=18/5000'
+            Example 2: 'api-usage=25/5000;
+                per-app-api-usage=17/250(appName=sample-connected-app)'
+        """
+        result = {}
+
+        api_usage = re.match(r'[^-]?api-usage=(?P<used>\d+)/(?P<tot>\d+)',
+                             sforce_limit_info)
+        pau = r'.+per-app-api-usage=(?P<u>\d+)/(?P<t>\d+)\(appName=(?P<n>.+)\)'
+        per_app_api_usage = re.match(pau, sforce_limit_info)
+
+        if api_usage and api_usage.groups():
+            groups = api_usage.groups()
+            result['api-usage'] = Usage(used=int(groups[0]),
+                                        total=int(groups[1]))
+        if per_app_api_usage and per_app_api_usage.groups():
+            groups = per_app_api_usage.groups()
+            result['per-app-api-usage'] = PerAppUsage(used=int(groups[0]),
+                                                      total=int(groups[1]),
+                                                      name=groups[2])
+
+        return result
+
+    # file-based deployment function
+    def deploy(self, zipfile, sandbox, **kwargs):
+
+        """Deploy using the Salesforce Metadata API. Wrapper for
+        SfdcMetaDataApi.deploy(...).
+
+        Arguments:
+
+        * zipfile: a .zip archive to deploy to an org, given as (
+        "path/to/zipfile.zip")
+        * options: salesforce DeployOptions in .json format.
+            (https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta
+            /api_meta/meta_deploy.htm)
+
+        Returns a process id and state for this deployment.
+        """
+        mdapi = SfdcMetadataApi(session=self.session,
+                                session_id=self.session_id,
+                                instance=self.sf_instance,
+                                sandbox=sandbox,
+                                metadata_url=self.metadata_url,
+                                api_version=self.sf_version,
+                                headers=self.headers)
+        asyncId, state = mdapi.deploy(zipfile, **kwargs)
+        result = {'asyncId': asyncId, 'state': state}
+        return result
+
+    # check on a file-based deployment
+    def checkDeployStatus(self, asyncId, sandbox, **kwargs):
+        """Check on the progress of a file-based deployment via Salesforce
+        Metadata API.
+        Wrapper for SfdcMetaDataApi.check_deploy_status(...).
+
+        Arguments:
+
+        * asyncId: deployment async process ID, returned by Salesforce.deploy()
+
+        Returns status of the deployment the asyncId given.
+        """
+        mdapi = SfdcMetadataApi(session=self.session,
+                                session_id=self.session_id,
+                                instance=self.sf_instance,
+                                sandbox=sandbox,
+                                metadata_url=self.metadata_url,
+                                api_version=self.sf_version,
+                                headers=self.headers)
+
+        state, state_detail, deployment_detail, unit_test_detail = \
+            mdapi.check_deploy_status(asyncId, **kwargs)
+        results = {
+            'state': state,
+            'state_detail': state_detail,
+            'deployment_detail': deployment_detail,
+            'unit_test_detail': unit_test_detail
+        }
+
+        return results
+
+
+class SFType:
+    """An interface to a specific type of SObject"""
+
+    # pylint: disable=too-many-arguments
+    def __init__(
+            self,
+            object_name,
+            session_id,
+            sf_instance,
+            sf_version=DEFAULT_API_VERSION,
+            proxies=None,
+            session=None,
+    ):
+        """Initialize the instance with the given parameters.
+
+        Arguments:
+
+        * object_name -- the name of the type of SObject this represents,
+                         e.g. `Lead` or `Contact`
+        * session_id -- the session ID for authenticating to Salesforce
+        * sf_instance -- the domain of the instance of Salesforce to use
+        * sf_version -- the version of the Salesforce API to use
+        * proxies -- the optional map of scheme to proxy server
+        * session -- Custom requests session, created in calling code. This
+                     enables the use of requests Session features not otherwise
+                     exposed by simple_salesforce.
+        """
+        self.session_id = session_id
+        self.name = object_name
+        self._session = session
+        self._proxies = proxies
+        # don't wipe out original proxies with None
+        if self._session and proxies is not None:
+            self._session.proxies = proxies
+        self.api_usage = {}
+
+        self.base_url = (
+            'https://{instance}/services/data/v{sf_version}/sobjects'
+            '/{object_name}/'.format(instance=sf_instance,
+                                     object_name=object_name,
+                                     sf_version=sf_version))
+
+    @property
+    def session(self):
+        """
+        Returns an AsyncClient which can be used as an async context manager
+        """
+        if self._session:
+            return self._session
+        if self._proxies:
+            return httpx.AsyncClient(proxies=self._proxies)
+        return httpx.AsyncClient()
+
+    async def metadata(self, headers=None):
+        """Returns the result of a GET to `.../{object_name}/` as a dict
+        decoded from the JSON payload returned by Salesforce.
+
+        Arguments:
+
+        * headers -- a dict with additional request headers.
+        """
+        result = await self._call_salesforce('GET', self.base_url, headers=headers)
+        return result.json(object_pairs_hook=OrderedDict)
+
+    async def describe(self, headers=None):
+        """Returns the result of a GET to `.../{object_name}/describe` as a
+        dict decoded from the JSON payload returned by Salesforce.
+
+        Arguments:
+
+        * headers -- a dict with additional request headers.
+        """
+        result = await self._call_salesforce(
+            method='GET', url=urljoin(self.base_url, 'describe'),
+            headers=headers
+        )
+        return result.json(object_pairs_hook=OrderedDict)
+
+    async def describe_layout(self, record_id, headers=None):
+        """Returns the layout of the object
+
+        Returns the result of a GET to
+        `.../{object_name}/describe/layouts/<recordid>` as a dict decoded from
+        the JSON payload returned by Salesforce.
+
+        Arguments:
+
+        * record_id -- the Id of the SObject to get
+        * headers -- a dict with additional request headers.
+        """
+        custom_url_part = 'describe/layouts/{record_id}'.format(
+            record_id=record_id
+        )
+        result = await self._call_salesforce(
+            method='GET',
+            url=urljoin(self.base_url, custom_url_part),
+            headers=headers
+        )
+        return result.json(object_pairs_hook=OrderedDict)
+
+    async def get(self, record_id, headers=None):
+        """Returns the result of a GET to `.../{object_name}/{record_id}` as a
+        dict decoded from the JSON payload returned by Salesforce.
+
+        Arguments:
+
+        * record_id -- the Id of the SObject to get
+        * headers -- a dict with additional request headers.
+        """
+        result = await self._call_salesforce(
+            method='GET', url=urljoin(self.base_url, record_id),
+            headers=headers
+        )
+        return result.json(object_pairs_hook=OrderedDict)
+
+    async def get_by_custom_id(self, custom_id_field, custom_id, headers=None):
+        """Return an ``SFType`` by custom ID
+
+        Returns the result of a GET to
+        `.../{object_name}/{custom_id_field}/{custom_id}` as a dict decoded
+        from the JSON payload returned by Salesforce.
+
+        Arguments:
+
+        * custom_id_field -- the API name of a custom field that was defined
+                             as an External ID
+        * custom_id - the External ID value of the SObject to get
+        * headers -- a dict with additional request headers.
+        """
+        custom_url = urljoin(
+            self.base_url, '{custom_id_field}/{custom_id}'.format(
+                custom_id_field=custom_id_field, custom_id=custom_id
+            )
+        )
+        result = await self._call_salesforce(
+            method='GET', url=custom_url, headers=headers
+        )
+        return result.json(object_pairs_hook=OrderedDict)
+
+    async def create(self, data, headers=None):
+        """Creates a new SObject using a POST to `.../{object_name}/`.
+
+        Returns a dict decoded from the JSON payload returned by Salesforce.
+
+        Arguments:
+
+        * data -- a dict of the data to create the SObject from. It will be
+                  JSON-encoded before being transmitted.
+        * headers -- a dict with additional request headers.
+        """
+        result = await self._call_salesforce(
+            method='POST', url=self.base_url,
+            data=json.dumps(data), headers=headers
+        )
+        return result.json(object_pairs_hook=OrderedDict)
+
+    async def upsert(self, record_id, data, raw_response=False, headers=None):
+        """Creates or updates an SObject using a PATCH to
+        `.../{object_name}/{record_id}`.
+
+        If `raw_response` is false (the default), returns the status code
+        returned by Salesforce. Otherwise, return the `requests.Response`
+        object.
+
+        Arguments:
+
+        * record_id -- an identifier for the SObject as described in the
+                       Salesforce documentation
+        * data -- a dict of the data to create or update the SObject from. It
+                  will be JSON-encoded before being transmitted.
+        * raw_response -- a boolean indicating whether to return the response
+                          directly, instead of the status code.
+        * headers -- a dict with additional request headers.
+        """
+        result = await self._call_salesforce(
+            method='PATCH', url=urljoin(self.base_url, record_id),
+            data=json.dumps(data), headers=headers
+        )
+        return self._raw_response(result, raw_response)
+
+    async def update(self, record_id, data, raw_response=False, headers=None):
+        """Updates an SObject using a PATCH to
+        `.../{object_name}/{record_id}`.
+
+        If `raw_response` is false (the default), returns the status code
+        returned by Salesforce. Otherwise, return the `requests.Response`
+        object.
+
+        Arguments:
+
+        * record_id -- the Id of the SObject to update
+        * data -- a dict of the data to update the SObject from. It will be
+                  JSON-encoded before being transmitted.
+        * raw_response -- a boolean indicating whether to return the response
+                          directly, instead of the status code.
+        * headers -- a dict with additional request headers.
+        """
+        result = await self._call_salesforce(
+            method='PATCH', url=urljoin(self.base_url, record_id),
+            data=json.dumps(data), headers=headers
+        )
+        return self._raw_response(result, raw_response)
+
+    async def delete(self, record_id, raw_response=False, headers=None):
+        """Deletes an SObject using a DELETE to
+        `.../{object_name}/{record_id}`.
+
+        If `raw_response` is false (the default), returns the status code
+        returned by Salesforce. Otherwise, return the `requests.Response`
+        object.
+
+        Arguments:
+
+        * record_id -- the Id of the SObject to delete
+        * raw_response -- a boolean indicating whether to return the response
+                          directly, instead of the status code.
+        * headers -- a dict with additional request headers.
+        """
+        result = await self._call_salesforce(
+            method='DELETE', url=urljoin(self.base_url, record_id),
+            headers=headers
+        )
+        return self._raw_response(result, raw_response)
+
+    async def deleted(self, start, end, headers=None):
+        # pylint: disable=line-too-long
+        """Gets a list of deleted records
+
+        Use the SObject Get Deleted resource to get a list of deleted records
+        for the specified object.
+        .../deleted/?start=2013-05-05T00:00:00+00:00&end=2013-05-10T00:00:00
+        +00:00
+
+        * start -- start datetime object
+        * end -- end datetime object
+        * headers -- a dict with additional request headers.
+        """
+        url = urljoin(
+            self.base_url, 'deleted/?start={start}&end={end}'.format(
+                start=date_to_iso8601(start), end=date_to_iso8601(end)
+            )
+        )
+        result = await self._call_salesforce(method='GET', url=url, headers=headers)
+        return result.json(object_pairs_hook=OrderedDict)
+
+    async def updated(self, start, end, headers=None):
+        # pylint: disable=line-too-long
+        """Gets a list of updated records
+
+        Use the SObject Get Updated resource to get a list of updated
+        (modified or added) records for the specified object.
+
+         .../updated/?start=2014-03-20T00:00:00+00:00&end=2014-03-22T00:00:00
+         +00:00
+
+        * start -- start datetime object
+        * end -- end datetime object
+        * headers -- a dict with additional request headers.
+        """
+        url = urljoin(
+            self.base_url, 'updated/?start={start}&end={end}'.format(
+                start=date_to_iso8601(start), end=date_to_iso8601(end)
+            )
+        )
+        result = await self._call_salesforce(method='GET', url=url, headers=headers)
+        return result.json(object_pairs_hook=OrderedDict)
+
+    async def _call_salesforce(self, method, url, **kwargs):
+        """Utility method for performing HTTP call to Salesforce.
+
+        Returns a `requests.result` object.
+        """
+        headers = {
+            'Content-Type': 'application/json',
+            'Authorization': 'Bearer ' + self.session_id,
+            'X-PrettyPrint': '1'
+        }
+        additional_headers = kwargs.pop('headers', dict())
+        headers.update(additional_headers or dict())
+        async with self.session as client:
+            result = await client.request(
+                method, url, headers=headers, **kwargs
+            )
+
+        if result.status_code >= 300:
+            exception_handler(result, self.name)
+
+        sforce_limit_info = result.headers.get('Sforce-Limit-Info')
+        if sforce_limit_info:
+            self.api_usage = AsyncSalesforce.parse_api_usage(sforce_limit_info)
+
+        return result
+
+    # pylint: disable=no-self-use
+    def _raw_response(self, response, body_flag):
+        """Utility method for processing the response and returning either the
+        status code or the response object.
+
+        Returns either an `int` or a `requests.Response` object.
+        """
+        if not body_flag:
+            return response.status_code
+
+        return response

--- a/simple_salesforce/aio/bulk.py
+++ b/simple_salesforce/aio/bulk.py
@@ -1,0 +1,334 @@
+""" Classes for interacting with Salesforce Bulk API """
+
+import json
+from collections import OrderedDict
+from time import sleep
+import concurrent.futures
+from functools import partial
+
+import httpx
+
+from simple_salesforce.util import list_from_generator
+from .aio_util import call_salesforce
+
+
+class SFBulkHandler:
+    """ Bulk API request handler
+    Intermediate class which allows us to use commands,
+     such as 'sf.bulk.Contacts.create(...)'
+    This is really just a middle layer, whose sole purpose is
+    to allow the above syntax
+    """
+
+    def __init__(self, session_id, bulk_url, proxies=None, session=None):
+        """Initialize the instance with the given parameters.
+
+        Arguments:
+
+        * session_id -- the session ID for authenticating to Salesforce
+        * bulk_url -- API endpoint set in Salesforce instance
+        * proxies -- the optional map of scheme to proxy server
+        * session -- Custom requests session, created in calling code. This
+                     enables the use of requests Session features not otherwise
+                     exposed by simple_salesforce.
+        """
+        self.session_id = session_id
+        self._session = session
+        self.bulk_url = bulk_url
+        # don't wipe out original proxies with None
+        if not session and proxies is not None:
+            self._proxies = proxies
+        elif session and proxies is not None:
+            self._session.proxies = proxies
+
+        # Define these headers separate from Salesforce class,
+        # as bulk uses a slightly different format
+        self.headers = {
+            'Content-Type': 'application/json',
+            'X-SFDC-Session': self.session_id,
+            'X-PrettyPrint': '1'
+            }
+
+    def __getattr__(self, name):
+        return SFBulkType(object_name=name, bulk_url=self.bulk_url,
+                          headers=self.headers, session=self._session)
+
+
+class SFBulkType:
+    """ Interface to Bulk/Async API functions"""
+
+    def __init__(self, object_name, bulk_url, headers, session):
+        """Initialize the instance with the given parameters.
+
+        Arguments:
+
+        * object_name -- the name of the type of SObject this represents,
+                         e.g. `Lead` or `Contact`
+        * bulk_url -- API endpoint set in Salesforce instance
+        * headers -- bulk API headers
+        * session -- Custom httpx session (AsyncClient) created in calling code.
+                    This enables the use of httpx AsyncClient features not
+                    otherwise exposed by simple_salesforce.
+        """
+        self.object_name = object_name
+        self.bulk_url = bulk_url
+        self._session = session
+        self.headers = headers
+
+    @property
+    def session(self):
+        """
+        Returns an AsyncClient which can be used as an async context manager
+        """
+        if self._session:
+            return self._session
+        return httpx.AsyncClient()
+
+    async def _create_job(self, operation, use_serial, external_id_field=None):
+        """ Create a bulk job
+
+        Arguments:
+
+        * operation -- Bulk operation to be performed by job
+        * use_serial -- Process batches in order
+        * external_id_field -- unique identifier field for upsert operations
+        """
+
+        if use_serial:
+            use_serial = 1
+        else:
+            use_serial = 0
+        payload = {
+            'operation': operation,
+            'object': self.object_name,
+            'concurrencyMode': use_serial,
+            'contentType': 'JSON'
+            }
+
+        if operation == 'upsert':
+            payload['externalIdFieldName'] = external_id_field
+
+        url = "{}{}".format(self.bulk_url, 'job')
+
+        result = await call_salesforce(
+            url=url, method='POST', session=self.session,
+            headers=self.headers,
+            data=json.dumps(payload, allow_nan=False)
+        )
+        return result.json(object_pairs_hook=OrderedDict)
+
+    async def _close_job(self, job_id):
+        """ Close a bulk job """
+        payload = {
+            'state': 'Closed'
+            }
+
+        url = "{}{}{}".format(self.bulk_url, 'job/', job_id)
+
+        result = await call_salesforce(
+            url=url, method='POST', session=self.session,
+            headers=self.headers,
+            data=json.dumps(payload, allow_nan=False)
+        )
+        return result.json(object_pairs_hook=OrderedDict)
+
+    async def _get_job(self, job_id):
+        """ Get an existing job to check the status """
+        url = "{}{}{}".format(self.bulk_url, 'job/', job_id)
+
+        result = await call_salesforce(
+            url=url, method='GET', session=self.session,
+            headers=self.headers
+        )
+        return result.json(object_pairs_hook=OrderedDict)
+
+    async def _add_batch(self, job_id, data, operation):
+        """ Add a set of data as a batch to an existing job
+        Separating this out in case of later
+        implementations involving multiple batches
+        """
+
+        url = "{}{}{}{}".format(self.bulk_url, 'job/', job_id, '/batch')
+
+        if operation not in ('query', 'queryAll'):
+            data = json.dumps(data, allow_nan=False)
+
+        result = await call_salesforce(
+            url=url, method='POST', session=self.session,
+            headers=self.headers, data=data
+        )
+        return result.json(object_pairs_hook=OrderedDict)
+
+    async def _get_batch(self, job_id, batch_id):
+        """ Get an existing batch to check the status """
+
+        url = "{}{}{}{}{}".format(self.bulk_url, 'job/',
+                                  job_id, '/batch/', batch_id)
+
+        result = await call_salesforce(
+            url=url, method='GET', session=self.session,
+            headers=self.headers
+        )
+        return result.json(object_pairs_hook=OrderedDict)
+
+    async def _get_batch_results(self, job_id, batch_id, operation):
+        """ retrieve a set of results from a completed job """
+
+        url = "{}{}{}{}{}{}".format(self.bulk_url, 'job/', job_id, '/batch/',
+                                    batch_id, '/result')
+
+        result = await call_salesforce(
+            url=url, method='GET', session=self.session,
+            headers=self.headers
+        )
+
+        if operation in ('query', 'queryAll'):
+            for batch_result in result.json():
+                url_query_results = "{}{}{}".format(url, '/', batch_result)
+                batch_query_result = await call_salesforce(
+                    url=url_query_results,
+                    method='GET',
+                    session=self.session,
+                    headers=self.headers
+                )
+                yield batch_query_result.json()
+        else:
+            yield result.json()
+
+    def worker(self, batch, operation, wait=5):
+        """ Gets batches from concurrent worker threads.
+        self._bulk_operation passes batch jobs.
+        The worker function checks each batch job waiting for it complete
+        and appends the results.
+        """
+
+        batch_status = self._get_batch(job_id=batch['jobId'],
+                                       batch_id=batch['id'])['state']
+
+        while batch_status not in ['Completed', 'Failed', 'Not Processed']:
+            sleep(wait)
+            batch_status = self._get_batch(job_id=batch['jobId'],
+                                           batch_id=batch['id'])['state']
+
+        batch_results = self._get_batch_results(job_id=batch['jobId'],
+                                                batch_id=batch['id'],
+                                                operation=operation)
+        result = batch_results
+        return result
+
+    # pylint: disable=R0913
+    def _bulk_operation(self, operation, data, use_serial=False,
+                        external_id_field=None, batch_size=10000, wait=5):
+        """ String together helper functions to create a complete
+        end-to-end bulk API request
+        Arguments:
+        * operation -- Bulk operation to be performed by job
+        * data -- list of dict to be passed as a batch
+        * use_serial -- Process batches in serial mode
+        * external_id_field -- unique identifier field for upsert operations
+        * wait -- seconds to sleep between checking batch status
+        * batch_size -- number of records to assign for each batch in the job
+        """
+
+        if operation not in ('query', 'queryAll'):
+            # Checks to prevent batch limit
+            if len(data) >= 10000 and batch_size > 10000:
+                batch_size = 10000
+            with concurrent.futures.ThreadPoolExecutor() as pool:
+
+                job = self._create_job(operation=operation,
+                                       use_serial=use_serial,
+                                       external_id_field=external_id_field)
+                batches = [
+                    self._add_batch(job_id=job['id'], data=i,
+                                    operation=operation)
+                    for i in
+                    [data[i * batch_size:(i + 1) * batch_size]
+                     for i in range((len(data) // batch_size + 1))] if i]
+
+                multi_thread_worker = partial(self.worker, operation=operation)
+                list_of_results = pool.map(multi_thread_worker, batches)
+
+                results = [x for sublist in list_of_results for i in
+                           sublist for x in i]
+
+                self._close_job(job_id=job['id'])
+
+        elif operation in ('query', 'queryAll'):
+            job = self._create_job(operation=operation,
+                                   use_serial=use_serial,
+                                   external_id_field=external_id_field)
+
+            batch = self._add_batch(job_id=job['id'], data=data,
+                                    operation=operation)
+
+            self._close_job(job_id=job['id'])
+
+            batch_status = self._get_batch(job_id=batch['jobId'],
+                                           batch_id=batch['id'])['state']
+
+            while batch_status not in ['Completed', 'Failed', 'Not Processed']:
+                sleep(wait)
+                batch_status = self._get_batch(job_id=batch['jobId'],
+                                               batch_id=batch['id'])['state']
+
+            results = self._get_batch_results(job_id=batch['jobId'],
+                                              batch_id=batch['id'],
+                                              operation=operation)
+        return results
+
+    # _bulk_operation wrappers to expose supported Salesforce bulk operations
+    def delete(self, data, batch_size=10000, use_serial=False):
+        """ soft delete records """
+        results = self._bulk_operation(use_serial=use_serial,
+                                       operation='delete', data=data,
+                                       batch_size=batch_size)
+        return results
+
+    def insert(self, data, batch_size=10000,
+               use_serial=False):
+        """ insert records """
+        results = self._bulk_operation(use_serial=use_serial,
+                                       operation='insert', data=data,
+                                       batch_size=batch_size)
+        return results
+
+    def upsert(self, data, external_id_field, batch_size=10000,
+               use_serial=False):
+        """ upsert records based on a unique identifier """
+        results = self._bulk_operation(use_serial=use_serial,
+                                       operation='upsert',
+                                       external_id_field=external_id_field,
+                                       data=data, batch_size=batch_size)
+        return results
+
+    def update(self, data, batch_size=10000, use_serial=False):
+        """ update records """
+        results = self._bulk_operation(use_serial=use_serial,
+                                       operation='update', data=data,
+                                       batch_size=batch_size)
+        return results
+
+    def hard_delete(self, data, batch_size=10000, use_serial=False):
+        """ hard delete records """
+        results = self._bulk_operation(use_serial=use_serial,
+                                       operation='hardDelete', data=data,
+                                       batch_size=batch_size)
+        return results
+
+    def query(self, data, lazy_operation=False):
+        """ bulk query """
+        results = self._bulk_operation(operation='query', data=data)
+
+        if lazy_operation:
+            return results
+
+        return list_from_generator(results)
+
+    def query_all(self, data, lazy_operation=False):
+        """ bulk queryAll """
+        results = self._bulk_operation(operation='queryAll', data=data)
+
+        if lazy_operation:
+            return results
+        return list_from_generator(results)

--- a/simple_salesforce/aio/bulk.py
+++ b/simple_salesforce/aio/bulk.py
@@ -386,7 +386,9 @@ class AsyncSFBulkType:
 
     async def query(self, data, lazy_operation=False, wait=5):
         """ bulk query """
-        results = await self._bulk_operation(operation='query', data=data, wait=wait)
+        results = await self._bulk_operation(
+            operation='query', data=data, wait=wait
+        )
 
         if lazy_operation:
             return results
@@ -395,7 +397,9 @@ class AsyncSFBulkType:
 
     async def query_all(self, data, lazy_operation=False, wait=5):
         """ bulk queryAll """
-        results = await self._bulk_operation(operation='queryAll', data=data, wait=wait)
+        results = await self._bulk_operation(
+            operation='queryAll', data=data, wait=wait
+        )
 
         if lazy_operation:
             return results

--- a/simple_salesforce/aio/login.py
+++ b/simple_salesforce/aio/login.py
@@ -1,4 +1,4 @@
-"""Login classes and functions for Simple-Salesforce
+"""Async Login classes and functions for Simple-Salesforce
 
 Heavily Modified from RestForce 1.0.0
 """
@@ -19,7 +19,7 @@ from simple_salesforce.util import getUniqueElementValueFromXmlString
 
 
 # pylint: disable=invalid-name,too-many-arguments,too-many-locals
-async def SalesforceLogin(
+async def AsyncSalesforceLogin(
     username=None,
     password=None,
     security_token=None,

--- a/simple_salesforce/aio/login.py
+++ b/simple_salesforce/aio/login.py
@@ -5,6 +5,7 @@ Heavily Modified from RestForce 1.0.0
 from datetime import datetime, timedelta, timezone
 from html import escape
 from json.decoder import JSONDecodeError
+import typing
 import warnings
 
 from authlib.jose import jwt
@@ -30,7 +31,7 @@ async def SalesforceLogin(
     consumer_key=None,
     privatekey_file=None,
     privatekey=None,
-):
+) -> typing.Tuple[str, str]:
     """Return a tuple of `(session_id, sf_instance)` where `session_id` is the
     session ID to use for authentication to Salesforce and `sf_instance` is
     the domain of the instance of Salesforce to use for the session.
@@ -163,6 +164,7 @@ async def SalesforceLogin(
             )
         }
         if privatekey_file is not None:
+            # TODO: Should be async so as not to block eventloop
             with open(privatekey_file, 'rb') as key_file:
                 key = key_file.read()
         else:

--- a/simple_salesforce/aio/login.py
+++ b/simple_salesforce/aio/login.py
@@ -1,0 +1,290 @@
+"""Login classes and functions for Simple-Salesforce
+
+Heavily Modified from RestForce 1.0.0
+"""
+from datetime import datetime, timedelta, timezone
+from html import escape
+from json.decoder import JSONDecodeError
+import warnings
+
+from authlib.jose import jwt
+import httpx
+
+from simple_salesforce.api import DEFAULT_API_VERSION
+from simple_salesforce.login import DEFAULT_CLIENT_ID_PREFIX
+from simple_salesforce.exceptions import SalesforceAuthenticationFailed
+from simple_salesforce.util import getUniqueElementValueFromXmlString
+
+
+# pylint: disable=invalid-name,too-many-arguments,too-many-locals
+async def SalesforceLogin(
+    username=None,
+    password=None,
+    security_token=None,
+    organizationId=None,
+    sf_version=DEFAULT_API_VERSION,
+    proxies=None,
+    session=None,
+    client_id=None,
+    domain=None,
+    consumer_key=None,
+    privatekey_file=None,
+    privatekey=None,
+):
+    """Return a tuple of `(session_id, sf_instance)` where `session_id` is the
+    session ID to use for authentication to Salesforce and `sf_instance` is
+    the domain of the instance of Salesforce to use for the session.
+
+    Arguments:
+
+    * username -- the Salesforce username to use for authentication
+    * password -- the password for the username
+    * security_token -- the security token for the username
+    * organizationId -- the ID of your organization
+            NOTE: security_token an organizationId are mutually exclusive
+    * sf_version -- the version of the Salesforce API to use, for example
+                    "27.0"
+    * proxies -- the optional map of scheme to proxy server (note: httpx style!)
+    * session -- Custom httpx session (AsyncClient), created in calling code. This
+                 enables the use of httpx AsyncClient features not otherwise
+                 exposed by simple_salesforce.
+    * client_id -- the ID of this client
+    * domain -- The domain to using for connecting to Salesforce. Use
+                common domains, such as 'login' or 'test', or
+                Salesforce My domain. If not used, will default to
+                'login'.
+    * consumer_key -- the consumer key generated for the user
+    * privatekey_file -- the path to the private key file used
+                         for signing the JWT token.
+    * privatekey -- the private key to use
+                         for signing the JWT token.
+    """
+
+    if domain is None:
+        domain = 'login'
+
+    soap_url = 'https://{domain}.salesforce.com/services/Soap/u/{sf_version}'
+
+    if client_id:
+        client_id = "{prefix}/{app_name}".format(
+            prefix=DEFAULT_CLIENT_ID_PREFIX,
+            app_name=client_id)
+    else:
+        client_id = DEFAULT_CLIENT_ID_PREFIX
+
+    soap_url = soap_url.format(domain=domain,
+                               sf_version=sf_version)
+
+    # pylint: disable=E0012,deprecated-method
+    username = escape(username) if username else None
+    password = escape(password) if password else None
+
+    # Check if token authentication is used
+    if security_token is not None:
+        # Security Token Soap request body
+        login_soap_request_body = """<?xml version="1.0" encoding="utf-8" ?>
+        <env:Envelope
+                xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xmlns:env="http://schemas.xmlsoap.org/soap/envelope/"
+                xmlns:urn="urn:partner.soap.sforce.com">
+            <env:Header>
+                <urn:CallOptions>
+                    <urn:client>{client_id}</urn:client>
+                    <urn:defaultNamespace>sf</urn:defaultNamespace>
+                </urn:CallOptions>
+            </env:Header>
+            <env:Body>
+                <n1:login xmlns:n1="urn:partner.soap.sforce.com">
+                    <n1:username>{username}</n1:username>
+                    <n1:password>{password}{token}</n1:password>
+                </n1:login>
+            </env:Body>
+        </env:Envelope>""".format(
+            username=username, password=password, token=security_token,
+            client_id=client_id)
+
+    # Check if IP Filtering is used in conjunction with organizationId
+    elif organizationId is not None:
+        # IP Filtering Login Soap request body
+        login_soap_request_body = """<?xml version="1.0" encoding="utf-8" ?>
+        <soapenv:Envelope
+                xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"
+                xmlns:urn="urn:partner.soap.sforce.com">
+            <soapenv:Header>
+                <urn:CallOptions>
+                    <urn:client>{client_id}</urn:client>
+                    <urn:defaultNamespace>sf</urn:defaultNamespace>
+                </urn:CallOptions>
+                <urn:LoginScopeHeader>
+                    <urn:organizationId>{organizationId}</urn:organizationId>
+                </urn:LoginScopeHeader>
+            </soapenv:Header>
+            <soapenv:Body>
+                <urn:login>
+                    <urn:username>{username}</urn:username>
+                    <urn:password>{password}</urn:password>
+                </urn:login>
+            </soapenv:Body>
+        </soapenv:Envelope>""".format(
+            username=username, password=password, organizationId=organizationId,
+            client_id=client_id)
+    elif username is not None and password is not None:
+        # IP Filtering for non self-service users
+        login_soap_request_body = """<?xml version="1.0" encoding="utf-8" ?>
+        <soapenv:Envelope
+                xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"
+                xmlns:urn="urn:partner.soap.sforce.com">
+            <soapenv:Header>
+                <urn:CallOptions>
+                    <urn:client>{client_id}</urn:client>
+                    <urn:defaultNamespace>sf</urn:defaultNamespace>
+                </urn:CallOptions>
+            </soapenv:Header>
+            <soapenv:Body>
+                <urn:login>
+                    <urn:username>{username}</urn:username>
+                    <urn:password>{password}</urn:password>
+                </urn:login>
+            </soapenv:Body>
+        </soapenv:Envelope>""".format(
+            username=username, password=password, client_id=client_id)
+    elif username is not None and \
+            consumer_key is not None and \
+            (privatekey_file is not None or privatekey is not None):
+        header = {'alg': 'RS256'}
+        expiration = datetime.now(timezone.utc) + timedelta(minutes=3)
+        payload = {
+            'iss': consumer_key,
+            'sub': username,
+            'aud': 'https://{domain}.salesforce.com'.format(domain=domain),
+            'exp': '{exp:.0f}'.format(
+                exp=expiration.timestamp()
+            )
+        }
+        if privatekey_file is not None:
+            with open(privatekey_file, 'rb') as key_file:
+                key = key_file.read()
+        else:
+            key = privatekey
+
+        assertion = jwt.encode(header, payload, key)
+
+        login_token_request_data = {
+            'grant_type': 'urn:ietf:params:oauth:grant-type:jwt-bearer',
+            'assertion': assertion.decode()
+        }
+
+        return await token_login(
+            'https://{domain}.salesforce.com/services/oauth2/token'.format(
+                domain=domain),
+            login_token_request_data, domain, consumer_key,
+            None, proxies, session)
+    else:
+        except_code = 'INVALID AUTH'
+        except_msg = (
+            'You must submit either a security token or organizationId for '
+            'authentication'
+        )
+        raise SalesforceAuthenticationFailed(except_code, except_msg)
+
+    login_soap_request_headers = {
+        'content-type': 'text/xml',
+        'charset': 'UTF-8',
+        'SOAPAction': 'login'
+    }
+
+    return await soap_login(
+        soap_url,
+        login_soap_request_body,
+        login_soap_request_headers,
+        proxies,
+        session
+    )
+
+
+async def soap_login(soap_url, request_body, headers, proxies, session=None):
+    """Process SOAP specific login workflow."""
+    if session:
+        client = session
+    elif proxies and not session:
+        client = httpx.AsyncClient(proxies=proxies)
+    else:
+        client = httpx.AsyncClient()
+
+    async with client:
+        response = await client.post(
+            soap_url, data=request_body, headers=headers
+        )
+
+    if response.status_code != 200:
+        except_code = getUniqueElementValueFromXmlString(
+            response.content, 'sf:exceptionCode')
+        except_msg = getUniqueElementValueFromXmlString(
+            response.content, 'sf:exceptionMessage')
+        raise SalesforceAuthenticationFailed(except_code, except_msg)
+
+    session_id = getUniqueElementValueFromXmlString(
+        response.content, 'sessionId')
+    server_url = getUniqueElementValueFromXmlString(
+        response.content, 'serverUrl')
+
+    sf_instance = (server_url
+                   .replace('http://', '')
+                   .replace('https://', '')
+                   .split('/')[0]
+                   .replace('-api', ''))
+
+    return session_id, sf_instance
+
+
+async def token_login(
+    token_url, token_data, domain, consumer_key, headers, proxies, session=None
+):
+    """Process OAuth 2.0 JWT Bearer Token Flow."""
+    if session:
+        client = session
+    elif proxies and not session:
+        client = httpx.AsyncClient(proxies=proxies)
+    else:
+        client = httpx.AsyncClient()
+
+    async with client:
+        response = await client.post(
+            token_url, data=token_data, headers=headers
+        )
+
+    try:
+        json_response = response.json()
+    except JSONDecodeError as exc:
+        raise SalesforceAuthenticationFailed(
+            response.status_code, response.text
+        ) from exc
+
+    if response.status_code != 200:
+        except_code = json_response.get('error')
+        except_msg = json_response.get('error_description')
+        if except_msg == "user hasn't approved this consumer":
+            auth_url = 'https://{domain}.salesforce.com/services/oauth2/' \
+                       'authorize?response_type=code&client_id=' \
+                       '{consumer_key}&redirect_uri=<approved URI>'.format(
+                            domain=domain,
+                            consumer_key=consumer_key
+                        )
+            warnings.warn("""
+    If your connected app policy is set to "All users may
+    self-authorize", you may need to authorize this
+    application first. Browse to
+    %s
+    in order to Allow Access. Check first to ensure you have a valid
+    <approved URI>.""" % auth_url)
+        raise SalesforceAuthenticationFailed(except_code, except_msg)
+
+    access_token = json_response.get('access_token')
+    instance_url = json_response.get('instance_url')
+
+    sf_instance = instance_url.replace(
+        'http://', '').replace(
+        'https://', '')
+
+    return access_token, sf_instance

--- a/simple_salesforce/aio/login.py
+++ b/simple_salesforce/aio/login.py
@@ -2,6 +2,7 @@
 
 Heavily Modified from RestForce 1.0.0
 """
+import aiofiles
 from datetime import datetime, timedelta, timezone
 from html import escape
 from json.decoder import JSONDecodeError
@@ -164,9 +165,8 @@ async def SalesforceLogin(
             )
         }
         if privatekey_file is not None:
-            # TODO: Should be async so as not to block eventloop
-            with open(privatekey_file, 'rb') as key_file:
-                key = key_file.read()
+            async with aiofiles.open(privatekey_file, 'rb') as key_file:
+                key = await key_file.read()
         else:
             key = privatekey
 

--- a/simple_salesforce/aio/metadata.py
+++ b/simple_salesforce/aio/metadata.py
@@ -1,0 +1,383 @@
+""" Class to work with Salesforce Metadata API """
+from base64 import b64encode, b64decode
+from xml.etree import ElementTree as ET
+
+from simple_salesforce.messages import DEPLOY_MSG, CHECK_DEPLOY_STATUS_MSG,\
+    CHECK_RETRIEVE_STATUS_MSG, RETRIEVE_MSG
+from .aio_util import call_salesforce
+
+
+class SfdcMetadataApi:
+    # pylint: disable=too-many-instance-attributes
+    """ Class to work with Salesforce Metadata API """
+    _METADATA_API_BASE_URI = "/services/Soap/m/{version}"
+    _XML_NAMESPACES = {
+        'soapenv': 'http://schemas.xmlsoap.org/soap/envelope/',
+        'mt': 'http://soap.sforce.com/2006/04/metadata'
+        }
+
+    # pylint: disable=R0913
+    def __init__(self, session, session_id, instance, sandbox, metadata_url,
+                 headers, api_version):
+        """ Initialize and check session """
+        self.session = session
+        self._session_id = session_id
+        self._instance = instance
+        self._sandbox = sandbox
+        self.metadata_url = metadata_url
+        self.headers = headers
+        self._api_version = api_version
+        self._deploy_zip = None
+
+    # pylint: disable=R0914
+    # pylint: disable-msg=C0103
+    async def deploy(self, zipfile, **kwargs):
+        """ Kicks off async deployment, returns deployment id
+        :param zipfile:
+        :type zipfile:
+        :param kwargs:
+        :type kwargs:
+        :return:
+        :rtype:
+        """
+        client = kwargs.get('client', 'simple_salesforce_metahelper')
+        checkOnly = kwargs.get('checkOnly', False)
+        testLevel = kwargs.get('testLevel')
+        tests = kwargs.get('tests')
+        ignoreWarnings = kwargs.get('ignoreWarnings', False)
+        allowMissingFiles = kwargs.get('allowMissingFiles', False)
+        autoUpdatePackage = kwargs.get('autoUpdatePackage', False)
+        performRetrieve = kwargs.get('performRetrieve', False)
+        purgeOnDelete = kwargs.get('purgeOnDelete', False)
+        rollbackOnError = kwargs.get('rollbackOnError', False)
+        singlePackage = True
+
+        attributes = {
+            'client': client,
+            'checkOnly': checkOnly,
+            'sessionId': self._session_id,
+            'ZipFile': self._read_deploy_zip(zipfile),
+            'testLevel': testLevel,
+            'tests': tests,
+            'ignoreWarnings': ignoreWarnings,
+            'allowMissingFiles': allowMissingFiles,
+            'autoUpdatePackage': autoUpdatePackage,
+            'performRetrieve': performRetrieve,
+            'purgeOnDelete': purgeOnDelete,
+            'rollbackOnError': rollbackOnError,
+            'singlePackage': singlePackage,
+            }
+
+        if not self._sandbox:
+            attributes['allowMissingFiles'] = False
+            attributes['rollbackOnError'] = True
+
+        if testLevel:
+            test_level = "<met:testLevel>%s</met:testLevel>" % testLevel
+            attributes['testLevel'] = test_level
+
+        tests_tag = ''
+        if tests and \
+                str(testLevel).lower() == 'runspecifiedtests':
+            for test in tests:
+                tests_tag += '<met:runTests>%s</met:runTests>\n' % test
+            attributes['tests'] = tests_tag
+
+        request = DEPLOY_MSG.format(**attributes)
+
+        headers = {'Content-Type': 'text/xml', 'SOAPAction': 'deploy'}
+        result = await call_salesforce(
+            url=self.metadata_url + 'deployRequest',
+            method='POST',
+            session=self.session,
+            headers=self.headers,
+            additional_headers=headers,
+            data=request
+        )
+
+        async_process_id = ET.fromstring(result.text).find(
+            'soapenv:Body/mt:deployResponse/mt:result/mt:id',
+            self._XML_NAMESPACES).text
+        state = ET.fromstring(result.text).find(
+            'soapenv:Body/mt:deployResponse/mt:result/mt:state',
+            self._XML_NAMESPACES).text
+
+        return async_process_id, state
+
+    @staticmethod
+    # pylint: disable=R1732
+    def _read_deploy_zip(zipfile):
+        """
+        :param zipfile:
+        :type zipfile:
+        :return:
+        :rtype:
+        """
+        if hasattr(zipfile, 'read'):
+            file = zipfile
+            file.seek(0)
+            should_close = False
+        else:
+            file = open(zipfile, 'rb')
+            should_close = True
+        raw = file.read()
+        if should_close:
+            file.close()
+        return b64encode(raw).decode("utf-8")
+
+    async def _retrieve_deploy_result(self, async_process_id, **kwargs):
+        """ Retrieves status for specified deployment id
+        :param async_process_id:
+        :type async_process_id:
+        :param kwargs:
+        :type kwargs:
+        :return:
+        :rtype:
+        """
+        client = kwargs.get('client', 'simple_salesforce_metahelper')
+
+        attributes = {
+            'client': client,
+            'sessionId': self._session_id,
+            'asyncProcessId': async_process_id,
+            'includeDetails': 'true'
+            }
+        mt_request = CHECK_DEPLOY_STATUS_MSG.format(**attributes)
+        headers = {
+            'Content-type': 'text/xml', 'SOAPAction': 'checkDeployStatus'
+            }
+
+        res = await call_salesforce(
+            url=self.metadata_url + 'deployRequest/' + async_process_id,
+            method='POST',
+            session=self.session,
+            headers=self.headers,
+            additional_headers=headers,
+            data=mt_request
+        )
+
+        root = ET.fromstring(res.text)
+        result = root.find(
+            'soapenv:Body/mt:checkDeployStatusResponse/mt:result',
+            self._XML_NAMESPACES)
+        if result is None:
+            raise Exception("Result node could not be found: %s" % res.text)
+
+        return result
+
+    @staticmethod
+    def get_component_error_count(value):
+        """Get component error counts"""
+        try:
+            return int(value)
+        except ValueError:
+            return 0
+
+    async def check_deploy_status(self, async_process_id, **kwargs):
+        """
+        Checks whether deployment succeeded
+        :param async_process_id:
+        :type async_process_id:
+        :param kwargs:
+        :type kwargs:
+        :return:
+        :rtype:
+        """
+        result = await self._retrieve_deploy_result(async_process_id, **kwargs)
+
+        state = result.find('mt:status', self._XML_NAMESPACES).text
+        state_detail = result.find('mt:stateDetail', self._XML_NAMESPACES)
+        if state_detail is not None:
+            state_detail = state_detail.text
+
+        unit_test_errors = []
+        deployment_errors = []
+        failed_count = self.get_component_error_count(
+            result.find('mt:numberComponentErrors', self._XML_NAMESPACES).text)
+        if state == 'Failed' or failed_count > 0:
+            # Deployment failures
+            failures = result.findall('mt:details/mt:componentFailures',
+                                      self._XML_NAMESPACES)
+            for failure in failures:
+                deployment_errors.append({
+                    'type': failure.find('mt:componentType',
+                                         self._XML_NAMESPACES).text,
+                    'file': failure.find('mt:fileName',
+                                         self._XML_NAMESPACES).text,
+                    'status': failure.find('mt:problemType',
+                                           self._XML_NAMESPACES).text,
+                    'message': failure.find('mt:problem',
+                                            self._XML_NAMESPACES).text
+                    })
+            # Unit test failures
+            failures = result.findall(
+                'mt:details/mt:runTestResult/mt:failures',
+                self._XML_NAMESPACES)
+            for failure in failures:
+                unit_test_errors.append({
+                    'class': failure.find('mt:name', self._XML_NAMESPACES).text,
+                    'method': failure.find('mt:methodName',
+                                           self._XML_NAMESPACES).text,
+                    'message': failure.find('mt:message',
+                                            self._XML_NAMESPACES).text,
+                    'stack_trace': failure.find('mt:stackTrace',
+                                                self._XML_NAMESPACES).text
+                    })
+
+        deployment_detail = {
+            'total_count': result.find('mt:numberComponentsTotal',
+                                       self._XML_NAMESPACES).text,
+            'failed_count': result.find('mt:numberComponentErrors',
+                                        self._XML_NAMESPACES).text,
+            'deployed_count': result.find('mt:numberComponentsDeployed',
+                                          self._XML_NAMESPACES).text,
+            'errors': deployment_errors
+            }
+        unit_test_detail = {
+            'total_count': result.find('mt:numberTestsTotal',
+                                       self._XML_NAMESPACES).text,
+            'failed_count': result.find('mt:numberTestErrors',
+                                        self._XML_NAMESPACES).text,
+            'completed_count': result.find('mt:numberTestsCompleted',
+                                           self._XML_NAMESPACES).text,
+            'errors': unit_test_errors
+            }
+
+        return state, state_detail, deployment_detail, unit_test_detail
+
+    async def download_unit_test_logs(self, async_process_id):
+        """ Downloads Apex logs for unit tests executed during specified
+        deployment """
+        result = await self._retrieve_deploy_result(async_process_id)
+        print("Results: %s" % ET.tostring(result, encoding="us-ascii",
+                                          method="xml"))
+
+    async def retrieve(self, async_process_id, **kwargs):
+        """ Submits retrieve request """
+        # Compose unpackaged XML
+        client = kwargs.get('client', 'simple_salesforce_metahelper')
+        single_package = kwargs.get('single_package', True)
+
+        if not isinstance(single_package, bool):
+            raise TypeError('single_package must be bool')
+
+        unpackaged = ''
+        if kwargs.get('unpackaged'):
+            for metadata_type in kwargs.get('unpackaged'):
+                if isinstance(kwargs.get('unpackaged'), dict):
+                    members = kwargs.get('unpackaged')[metadata_type]
+                    unpackaged += '<types>'
+                    for member in members:
+                        unpackaged += '<members>{member}</members>'.format(
+                            member=member)
+                    unpackaged += '<name>{metadata_type}</name></types>'.format(
+                        metadata_type=metadata_type)
+                else:
+                    raise TypeError('unpackaged metadata types must be a dict')
+
+        # Compose retrieve request XML
+        attributes = {
+            'client': client,
+            'sessionId': self._session_id,
+            'apiVersion': self._api_version,
+            'singlePackage': single_package,
+            'unpackaged': unpackaged
+            }
+        request = RETRIEVE_MSG.format(**attributes)
+        # Submit request
+        headers = {'Content-type': 'text/xml', 'SOAPAction': 'retrieve'}
+
+        res = await call_salesforce(
+            url=self.metadata_url + 'deployRequest/' + async_process_id,
+            method='POST',
+            session=self.session,
+            headers=self.headers,
+            additional_headers=headers,
+            data=request)
+
+        # Parse results to get async Id and status
+        async_process_id = ET.fromstring(res.text).find(
+            'soapenv:Body/mt:retrieveResponse/mt:result/mt:id',
+            self._XML_NAMESPACES).text
+        state = ET.fromstring(res.text).find(
+            'soapenv:Body/mt:retrieveResponse/mt:result/mt:state',
+            self._XML_NAMESPACES).text
+
+        return async_process_id, state
+
+    async def retrieve_retrieve_result(self, async_process_id, include_zip, **kwargs):
+        """ Retrieves status for specified retrieval id """
+        client = kwargs.get('client', 'simple_salesforce_metahelper')
+        attributes = {
+            'client': client,
+            'sessionId': self._session_id,
+            'asyncProcessId': async_process_id,
+            'includeZip': include_zip
+            }
+        mt_request = CHECK_RETRIEVE_STATUS_MSG.format(**attributes)
+        headers = {
+            'Content-type': 'text/xml', 'SOAPAction': 'checkRetrieveStatus'
+            }
+        res = await call_salesforce(
+            url=self.metadata_url + 'deployRequest/' + async_process_id,
+            method='POST',
+            session=self.session,
+            headers=self.headers,
+            additional_headers=headers,
+            data=mt_request)
+
+        root = ET.fromstring(res.text)
+        result = root.find(
+            'soapenv:Body/mt:checkRetrieveStatusResponse/mt:result',
+            self._XML_NAMESPACES)
+        if result is None:
+            raise Exception("Result node could not be found: %s" % res.text)
+
+        return result
+
+    async def retrieve_zip(self, async_process_id, **kwargs):
+        """ Retrieves ZIP file """
+        result = await self.retrieve_retrieve_result(
+            async_process_id, 'true', **kwargs
+        )
+        state = result.find('mt:status', self._XML_NAMESPACES).text
+        error_message = result.find('mt:errorMessage', self._XML_NAMESPACES)
+        if error_message is not None:
+            error_message = error_message.text
+
+        # Check if there are any messages
+        messages = []
+        message_list = result.findall('mt:details/mt:messages',
+                                      self._XML_NAMESPACES)
+        for message in message_list:
+            messages.append({
+                'file': message.find('mt:fileName', self._XML_NAMESPACES).text,
+                'message': message.find('mt:problem', self._XML_NAMESPACES).text
+                })
+
+        # Retrieve base64 encoded ZIP file
+        zipfile_base64 = result.find('mt:zipFile', self._XML_NAMESPACES).text
+        zipfile = b64decode(zipfile_base64)
+
+        return state, error_message, messages, zipfile
+
+    async def check_retrieve_status(self, async_process_id, **kwargs):
+        """ Checks whether retrieval succeeded """
+        result = await self.retrieve_retrieve_result(async_process_id, 'false',
+                                                **kwargs)
+        state = result.find('mt:status', self._XML_NAMESPACES).text
+        error_message = result.find('mt:errorMessage', self._XML_NAMESPACES)
+        if error_message is not None:
+            error_message = error_message.text
+
+        # Check if there are any messages
+        messages = []
+        message_list = result.findall('mt:details/mt:messages',
+                                      self._XML_NAMESPACES)
+        for message in message_list:
+            messages.append({
+                'file': message.find('mt:fileName', self._XML_NAMESPACES).text,
+                'message': message.find('mt:problem', self._XML_NAMESPACES).text
+                })
+
+        return state, error_message, messages

--- a/simple_salesforce/aio/metadata.py
+++ b/simple_salesforce/aio/metadata.py
@@ -1,4 +1,4 @@
-""" Class to work with Salesforce Metadata API """
+"""Async Class to work with Salesforce Metadata API """
 from base64 import b64encode, b64decode
 from xml.etree import ElementTree as ET
 
@@ -9,7 +9,7 @@ from simple_salesforce.messages import DEPLOY_MSG, CHECK_DEPLOY_STATUS_MSG,\
 from .aio_util import call_salesforce
 
 
-class SfdcMetadataApi:
+class AsyncSfdcMetadataApi:
     # pylint: disable=too-many-instance-attributes
     """ Class to work with Salesforce Metadata API """
     _METADATA_API_BASE_URI = "/services/Soap/m/{version}"
@@ -124,7 +124,7 @@ class SfdcMetadataApi:
             should_close = True
         raw = await file.read()
         if should_close:
-            file.close()
+            await file.close()
         return b64encode(raw).decode("utf-8")
 
     async def _retrieve_deploy_result(self, async_process_id, **kwargs):

--- a/simple_salesforce/aio/metadata.py
+++ b/simple_salesforce/aio/metadata.py
@@ -2,6 +2,8 @@
 from base64 import b64encode, b64decode
 from xml.etree import ElementTree as ET
 
+import aiofiles
+
 from simple_salesforce.messages import DEPLOY_MSG, CHECK_DEPLOY_STATUS_MSG,\
     CHECK_RETRIEVE_STATUS_MSG, RETRIEVE_MSG
 from .aio_util import call_salesforce
@@ -56,7 +58,7 @@ class SfdcMetadataApi:
             'client': client,
             'checkOnly': checkOnly,
             'sessionId': self._session_id,
-            'ZipFile': self._read_deploy_zip(zipfile),
+            'ZipFile': await self._read_deploy_zip(zipfile),
             'testLevel': testLevel,
             'tests': tests,
             'ignoreWarnings': ignoreWarnings,
@@ -106,7 +108,7 @@ class SfdcMetadataApi:
 
     @staticmethod
     # pylint: disable=R1732
-    def _read_deploy_zip(zipfile):
+    async def _read_deploy_zip(zipfile):
         """
         :param zipfile:
         :type zipfile:
@@ -115,12 +117,12 @@ class SfdcMetadataApi:
         """
         if hasattr(zipfile, 'read'):
             file = zipfile
-            file.seek(0)
+            await file.seek(0)
             should_close = False
         else:
-            file = open(zipfile, 'rb')
+            file = await aiofiles.open(zipfile, 'rb')
             should_close = True
-        raw = file.read()
+        raw = await file.read()
         if should_close:
             file.close()
         return b64encode(raw).decode("utf-8")

--- a/simple_salesforce/tests/test_aio/conftest.py
+++ b/simple_salesforce/tests/test_aio/conftest.py
@@ -6,6 +6,8 @@ from unittest import mock
 import httpx
 import pytest
 
+from simple_salesforce.aio import AsyncSalesforce
+
 
 SESSION_ID = '12345'
 INSTANCE_URL = 'https://na15.salesforce.com'
@@ -162,3 +164,21 @@ def mock_httpx_client(monkeypatch):
     monkeypatch.setattr(httpx, "AsyncClient", mock_httpx.AsyncClient)
 
     return mock_httpx, mock_client, inner
+
+
+# pylint: disable=unused-argument
+# pylint: disable=redefined-outer-name
+@pytest.fixture()
+def sf_client(constants, mock_httpx_client):
+    """Simple fixture for crafting the client used below"""
+    client = AsyncSalesforce(
+        session_id=constants["SESSION_ID"],
+        proxies=constants["PROXIES"]
+    )
+    client.headers = {}
+    client.base_url = 'https://localhost/'
+    client.metadata_url = 'https://localhost/metadata/'
+    client.bulk_url = 'https://localhost/async/'
+    client.apex_url = 'https://localhost/apexrest/'
+    client.tooling_url = 'https://localhost/tooling/'
+    return client

--- a/simple_salesforce/tests/test_aio/conftest.py
+++ b/simple_salesforce/tests/test_aio/conftest.py
@@ -9,11 +9,13 @@ import pytest
 from simple_salesforce.aio import AsyncSalesforce
 
 
-SESSION_ID = '12345'
-INSTANCE_URL = 'https://na15.salesforce.com'
-TOKEN_ID = 'https://na15.salesforce.com/id/00Di0000000icUB/0DFi00000008UYO'
-METADATA_URL = 'https://na15.salesforce.com/services/Soap/m/29.0/00Di0000000icUB'
-SERVER_URL = 'https://na15.salesforce.com/services/Soap/c/29.0/00Di0000000icUB/0DFi00000008UYO'
+SESSION_ID = "12345"
+INSTANCE_URL = "https://na15.salesforce.com"
+TOKEN_ID = "https://na15.salesforce.com/id/00Di0000000icUB/0DFi00000008UYO"
+METADATA_URL = "https://na15.salesforce.com/services/Soap/m/29.0/00Di0000000icUB"
+SERVER_URL = (
+    "https://na15.salesforce.com/services/Soap/c/29.0/00Di0000000icUB/0DFi00000008UYO"
+)
 PROXIES = {
     "http": "http://10.10.1.10:3128",
     "https": "http://10.10.1.10:1080",
@@ -58,7 +60,11 @@ LOGIN_RESPONSE_SUCCESS = """<?xml version="1.0" encoding="UTF-8"?>
       </loginResponse>
    </soapenv:Body>
 </soapenv:Envelope>
-""" % (METADATA_URL, SERVER_URL, SESSION_ID)
+""" % (
+    METADATA_URL,
+    SERVER_URL,
+    SESSION_ID,
+)
 
 TOKEN_LOGIN_RESPONSE_SUCCESS = """{
     "access_token": "%s",
@@ -66,7 +72,11 @@ TOKEN_LOGIN_RESPONSE_SUCCESS = """{
     "instance_url": "%s",
     "id": "%s",
     "token_type": "Bearer"
-}""" % (SESSION_ID, INSTANCE_URL, TOKEN_ID)
+}""" % (
+    SESSION_ID,
+    INSTANCE_URL,
+    TOKEN_ID,
+)
 
 TOKEN_WARNING = """
     If your connected app policy is set to "All users may
@@ -103,9 +113,9 @@ ORGANIZATION_LIMITS_RESPONSE = {
 }
 
 BULK_HEADERS = {
-    'Content-Type': 'application/json',
-    'X-SFDC-Session': "%s" % SESSION_ID,
-    'X-PrettyPrint': '1'
+    "Content-Type": "application/json",
+    "X-SFDC-Session": "%s" % SESSION_ID,
+    "X-PrettyPrint": "1",
 }
 
 ALL_CONSTANTS = {
@@ -114,15 +124,15 @@ ALL_CONSTANTS = {
     "TOKEN_WARNING": TOKEN_WARNING,
     "ORGANIZATION_LIMITS_RESPONSE": ORGANIZATION_LIMITS_RESPONSE,
     "BULK_HEADERS": BULK_HEADERS,
-    "SESSION_ID": '12345',
-    "INSTANCE_URL": 'https://na15.salesforce.com',
-    "TOKEN_ID": 'https://na15.salesforce.com/id/00Di0000000icUB/0DFi00000008UYO',
-    "METADATA_URL": 'https://na15.salesforce.com/services/Soap/m/29.0/00Di0000000icUB',
-    "SERVER_URL": 'https://na15.salesforce.com/services/Soap/c/29.0/00Di0000000icUB/0DFi00000008UYO',
+    "SESSION_ID": "12345",
+    "INSTANCE_URL": "https://na15.salesforce.com",
+    "TOKEN_ID": "https://na15.salesforce.com/id/00Di0000000icUB/0DFi00000008UYO",
+    "METADATA_URL": "https://na15.salesforce.com/services/Soap/m/29.0/00Di0000000icUB",
+    "SERVER_URL": "https://na15.salesforce.com/services/Soap/c/29.0/00Di0000000icUB/0DFi00000008UYO",
     "PROXIES": {
         "http://": "http://10.10.1.10:3128",
         "https://": "http://10.10.1.10:1080",
-    }
+    },
 }
 
 
@@ -172,13 +182,12 @@ def mock_httpx_client(monkeypatch):
 def sf_client(constants, mock_httpx_client):
     """Simple fixture for crafting the client used below"""
     client = AsyncSalesforce(
-        session_id=constants["SESSION_ID"],
-        proxies=constants["PROXIES"]
+        session_id=constants["SESSION_ID"], proxies=constants["PROXIES"]
     )
     client.headers = {}
-    client.base_url = 'https://localhost/'
-    client.metadata_url = 'https://localhost/metadata/'
-    client.bulk_url = 'https://localhost/async/'
-    client.apex_url = 'https://localhost/apexrest/'
-    client.tooling_url = 'https://localhost/tooling/'
+    client.base_url = "https://localhost/"
+    client.metadata_url = "https://localhost/metadata/"
+    client.bulk_url = "https://localhost/async/"
+    client.apex_url = "https://localhost/apexrest/"
+    client.tooling_url = "https://localhost/tooling/"
     return client

--- a/simple_salesforce/tests/test_aio/conftest.py
+++ b/simple_salesforce/tests/test_aio/conftest.py
@@ -1,0 +1,164 @@
+"""
+Common fixtures for tests in this directory
+"""
+from unittest import mock
+
+import httpx
+import pytest
+
+
+SESSION_ID = '12345'
+INSTANCE_URL = 'https://na15.salesforce.com'
+TOKEN_ID = 'https://na15.salesforce.com/id/00Di0000000icUB/0DFi00000008UYO'
+METADATA_URL = 'https://na15.salesforce.com/services/Soap/m/29.0/00Di0000000icUB'
+SERVER_URL = 'https://na15.salesforce.com/services/Soap/c/29.0/00Di0000000icUB/0DFi00000008UYO'
+PROXIES = {
+    "http": "http://10.10.1.10:3128",
+    "https": "http://10.10.1.10:1080",
+}
+
+LOGIN_RESPONSE_SUCCESS = """<?xml version="1.0" encoding="UTF-8"?>
+<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns="urn:enterprise.soap.sforce.com" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+   <soapenv:Body>
+      <loginResponse>
+         <result>
+            <metadataServerUrl>%s</metadataServerUrl>
+            <passwordExpired>false</passwordExpired>
+            <sandbox>false</sandbox>
+            <serverUrl>%s</serverUrl>
+            <sessionId>%s</sessionId>
+            <userId>005i0000002MUqLAAW</userId>
+            <userInfo>
+               <accessibilityMode>false</accessibilityMode>
+               <currencySymbol>$</currencySymbol>
+               <orgAttachmentFileSizeLimit>5242880</orgAttachmentFileSizeLimit>
+               <orgDefaultCurrencyIsoCode>USD</orgDefaultCurrencyIsoCode>
+               <orgDisallowHtmlAttachments>false</orgDisallowHtmlAttachments>
+               <orgHasPersonAccounts>false</orgHasPersonAccounts>
+               <organizationId>00Di0000000icUBEAY</organizationId>
+               <organizationMultiCurrency>false</organizationMultiCurrency>
+               <organizationName>salesforce.com</organizationName>
+               <profileId>00ei0000001CMKcAAO</profileId>
+               <roleId xsi:nil="true" />
+               <sessionSecondsValid>7200</sessionSecondsValid>
+               <userDefaultCurrencyIsoCode xsi:nil="true" />
+               <userEmail>you@yourdomain.com</userEmail>
+               <userFullName>Wade Wegner</userFullName>
+               <userId>1234</userId>
+               <userLanguage>en_US</userLanguage>
+               <userLocale>en_US</userLocale>
+               <userName>you@yourdomain.com</userName>
+               <userTimeZone>America/Los_Angeles</userTimeZone>
+               <userType>Standard</userType>
+               <userUiSkin>Theme3</userUiSkin>
+            </userInfo>
+         </result>
+      </loginResponse>
+   </soapenv:Body>
+</soapenv:Envelope>
+""" % (METADATA_URL, SERVER_URL, SESSION_ID)
+
+TOKEN_LOGIN_RESPONSE_SUCCESS = """{
+    "access_token": "%s",
+    "scope": "web api",
+    "instance_url": "%s",
+    "id": "%s",
+    "token_type": "Bearer"
+}""" % (SESSION_ID, INSTANCE_URL, TOKEN_ID)
+
+TOKEN_WARNING = """
+    If your connected app policy is set to "All users may
+    self-authorize", you may need to authorize this
+    application first. Browse to
+    https://login.salesforce.com/services/oauth2/authorize?response_type=code&client_id=12345.abcde&redirect_uri=<approved URI>
+    in order to Allow Access. Check first to ensure you have a valid
+    <approved URI>."""
+
+ORGANIZATION_LIMITS_RESPONSE = {
+    "ConcurrentAsyncGetReportInstances": {"Max": 200, "Remaining": 200},
+    "ConcurrentSyncReportRuns": {"Max": 20, "Remaining": 20},
+    "DailyApiRequests": {"Max": 15000, "Remaining": 14998},
+    "DailyAsyncApexExecutions": {"Max": 250000, "Remaining": 250000},
+    "DailyBulkApiRequests": {"Max": 5000, "Remaining": 5000},
+    "DailyDurableGenericStreamingApiEvents": {"Max": 10000, "Remaining": 10000},
+    "DailyDurableStreamingApiEvents": {"Max": 10000, "Remaining": 10000},
+    "DailyGenericStreamingApiEvents": {"Max": 10000, "Remaining": 10000},
+    "DailyStreamingApiEvents": {"Max": 10000, "Remaining": 10000},
+    "DailyWorkflowEmails": {"Max": 390, "Remaining": 390},
+    "DataStorageMB": {"Max": 5, "Remaining": 5},
+    "DurableStreamingApiConcurrentClients": {"Max": 20, "Remaining": 20},
+    "FileStorageMB": {"Max": 20, "Remaining": 20},
+    "HourlyAsyncReportRuns": {"Max": 1200, "Remaining": 1200},
+    "HourlyDashboardRefreshes": {"Max": 200, "Remaining": 200},
+    "HourlyDashboardResults": {"Max": 5000, "Remaining": 5000},
+    "HourlyDashboardStatuses": {"Max": 999999999, "Remaining": 999999999},
+    "HourlyODataCallout": {"Max": 10000, "Remaining": 9999},
+    "HourlySyncReportRuns": {"Max": 500, "Remaining": 500},
+    "HourlyTimeBasedWorkflow": {"Max": 50, "Remaining": 50},
+    "MassEmail": {"Max": 10, "Remaining": 10},
+    "SingleEmail": {"Max": 15, "Remaining": 15},
+    "StreamingApiConcurrentClients": {"Max": 20, "Remaining": 20},
+}
+
+BULK_HEADERS = {
+    'Content-Type': 'application/json',
+    'X-SFDC-Session': "%s" % SESSION_ID,
+    'X-PrettyPrint': '1'
+}
+
+ALL_CONSTANTS = {
+    "LOGIN_RESPONSE_SUCCESS": LOGIN_RESPONSE_SUCCESS,
+    "TOKEN_LOGIN_RESPONSE_SUCCESS": TOKEN_LOGIN_RESPONSE_SUCCESS,
+    "TOKEN_WARNING": TOKEN_WARNING,
+    "ORGANIZATION_LIMITS_RESPONSE": ORGANIZATION_LIMITS_RESPONSE,
+    "BULK_HEADERS": BULK_HEADERS,
+    "SESSION_ID": '12345',
+    "INSTANCE_URL": 'https://na15.salesforce.com',
+    "TOKEN_ID": 'https://na15.salesforce.com/id/00Di0000000icUB/0DFi00000008UYO',
+    "METADATA_URL": 'https://na15.salesforce.com/services/Soap/m/29.0/00Di0000000icUB',
+    "SERVER_URL": 'https://na15.salesforce.com/services/Soap/c/29.0/00Di0000000icUB/0DFi00000008UYO',
+    "PROXIES": {
+        "http://": "http://10.10.1.10:3128",
+        "https://": "http://10.10.1.10:1080",
+    }
+}
+
+
+@pytest.fixture()
+def constants():
+    """Constants defined above as a pytest fixture"""
+    return ALL_CONSTANTS
+
+
+@pytest.fixture(autouse=True)
+def mock_httpx_client(monkeypatch):
+    """
+    Build a mock httpx interface to prevent http calls
+    """
+    mock_httpx = mock.MagicMock(httpx)
+    # prep client
+    mock_client = mock.MagicMock(httpx.AsyncClient)
+    mock_client.__aenter__ = mock.AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = mock.AsyncMock()
+    mock_client.get = mock.AsyncMock()
+    mock_client.post = mock.AsyncMock()
+    mock_client.put = mock.AsyncMock()
+    mock_client.delete = mock.AsyncMock()
+
+    mock_httpx.AsyncClient.return_value = mock_client
+
+    def inner(resp):
+        """
+        Allows callers to dynamically set the response value on each method.
+        They can also do this with `mock_client` object as well.
+        """
+        mock_client.request = mock.AsyncMock(return_value=resp)
+        mock_client.get = mock.AsyncMock(return_value=resp)
+        mock_client.post = mock.AsyncMock(return_value=resp)
+        mock_client.put = mock.AsyncMock(return_value=resp)
+        mock_client.delete = mock.AsyncMock(return_value=resp)
+        return mock_client
+
+    monkeypatch.setattr(httpx, "AsyncClient", mock_httpx.AsyncClient)
+
+    return mock_httpx, mock_client, inner

--- a/simple_salesforce/tests/test_aio/test_aio_util.py
+++ b/simple_salesforce/tests/test_aio/test_aio_util.py
@@ -3,11 +3,13 @@ import httpx
 
 import pytest
 
-from simple_salesforce.exceptions import (SalesforceExpiredSession,
-                                          SalesforceMalformedRequest,
-                                          SalesforceMoreThanOneRecord,
-                                          SalesforceRefusedRequest,
-                                          SalesforceResourceNotFound)
+from simple_salesforce.exceptions import (
+    SalesforceExpiredSession,
+    SalesforceMalformedRequest,
+    SalesforceMoreThanOneRecord,
+    SalesforceRefusedRequest,
+    SalesforceResourceNotFound,
+)
 from simple_salesforce.aio.aio_util import call_salesforce
 
 
@@ -18,25 +20,38 @@ async def test_call_salesforce_happy_path(mock_httpx_client):
     happy_result = httpx.Response(200)
     inner(happy_result)
     # no exceptions
-    assert await call_salesforce(method="GET", url="www.example.com", async_client=mock_client) is happy_result
-    assert await call_salesforce(method="GET", url="www.example.com", ) is happy_result
+    assert (
+        await call_salesforce(
+            method="GET", url="www.example.com", async_client=mock_client
+        )
+        is happy_result
+    )
+    assert await call_salesforce(method="GET", url="www.example.com",) is happy_result
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("status_code,exception_class", (
-    (300, SalesforceMoreThanOneRecord),
-    (400, SalesforceMalformedRequest),
-    (401, SalesforceExpiredSession),
-    (403, SalesforceRefusedRequest),
-    (404, SalesforceResourceNotFound),
-
-))
-async def test_call_salesforce_exceptions(status_code, exception_class, mock_httpx_client):
+@pytest.mark.parametrize(
+    "status_code,exception_class",
+    (
+        (300, SalesforceMoreThanOneRecord),
+        (400, SalesforceMalformedRequest),
+        (401, SalesforceExpiredSession),
+        (403, SalesforceRefusedRequest),
+        (404, SalesforceResourceNotFound),
+    ),
+)
+async def test_call_salesforce_exceptions(
+    status_code, exception_class, mock_httpx_client
+):
     """Test exception-handling responses: => 300"""
     _, mock_client, inner = mock_httpx_client
-    exc_result = httpx.Response(status_code, request=httpx.Request("GET", "www.example.com"))
+    exc_result = httpx.Response(
+        status_code, request=httpx.Request("GET", "www.example.com")
+    )
     inner(exc_result)
     with pytest.raises(exception_class):
-        await call_salesforce(method="GET", url="www.example.com", async_client=mock_client)
+        await call_salesforce(
+            method="GET", url="www.example.com", async_client=mock_client
+        )
     with pytest.raises(exception_class):
         await call_salesforce(method="GET", url="www.example.com")

--- a/simple_salesforce/tests/test_aio/test_aio_util.py
+++ b/simple_salesforce/tests/test_aio/test_aio_util.py
@@ -1,0 +1,42 @@
+"""Tests for simple-salesforce aio utility functions"""
+import httpx
+
+import pytest
+
+from simple_salesforce.exceptions import (SalesforceExpiredSession,
+                                          SalesforceMalformedRequest,
+                                          SalesforceMoreThanOneRecord,
+                                          SalesforceRefusedRequest,
+                                          SalesforceResourceNotFound)
+from simple_salesforce.aio.aio_util import call_salesforce
+
+
+@pytest.mark.asyncio
+async def test_call_salesforce_happy_path(mock_httpx_client):
+    """Test happy path responses: <= 300"""
+    _, mock_client, inner = mock_httpx_client
+    happy_result = httpx.Response(200)
+    inner(happy_result)
+    # no exceptions
+    assert await call_salesforce(method="GET", url="www.example.com", async_client=mock_client) is happy_result
+    assert await call_salesforce(method="GET", url="www.example.com", ) is happy_result
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("status_code,exception_class", (
+    (300, SalesforceMoreThanOneRecord),
+    (400, SalesforceMalformedRequest),
+    (401, SalesforceExpiredSession),
+    (403, SalesforceRefusedRequest),
+    (404, SalesforceResourceNotFound),
+
+))
+async def test_call_salesforce_exceptions(status_code, exception_class, mock_httpx_client):
+    """Test exception-handling responses: => 300"""
+    _, mock_client, inner = mock_httpx_client
+    exc_result = httpx.Response(status_code, request=httpx.Request("GET", "www.example.com"))
+    inner(exc_result)
+    with pytest.raises(exception_class):
+        await call_salesforce(method="GET", url="www.example.com", async_client=mock_client)
+    with pytest.raises(exception_class):
+        await call_salesforce(method="GET", url="www.example.com")

--- a/simple_salesforce/tests/test_aio/test_api.py
+++ b/simple_salesforce/tests/test_aio/test_api.py
@@ -12,7 +12,9 @@ import pytest
 
 from simple_salesforce.api import PerAppUsage, Usage
 from simple_salesforce.aio.api import (
-    build_async_salesforce_client, AsyncSalesforce, AsyncSFType
+    build_async_salesforce_client,
+    AsyncSalesforce,
+    AsyncSFType,
 )
 from simple_salesforce.exceptions import SalesforceGeneralError
 from simple_salesforce.util import date_to_iso8601
@@ -29,34 +31,30 @@ CASE_URL = DEFAULT_URL.format("Case")
 
 
 def _create_sf_type(
-        object_name='Case',
-        session_id='5',
-        sf_instance='my.salesforce.com'
-        ):
+    object_name="Case", session_id="5", sf_instance="my.salesforce.com"
+):
     """Creates AsyncSFType instances"""
     return AsyncSFType(
         object_name=object_name,
         session_id=session_id,
         sf_instance=sf_instance,
-        session=httpx.AsyncClient()
-        )
+        session=httpx.AsyncClient(),
+    )
 
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("with_headers", (True, False))
-async def test_metadata_with_request_headers(
-    with_headers, mock_httpx_client
-):
+async def test_metadata_with_request_headers(with_headers, mock_httpx_client):
     """
     Ensure custom headers are used for metadata requests
     when passed.
     """
     _, mock_client, inner = mock_httpx_client
-    happy_result = httpx.Response(200, content=b'{}')
+    happy_result = httpx.Response(200, content=b"{}")
     inner(happy_result)
 
     sf_type = _create_sf_type()
-    headers = {'Sforce-Auto-Assign': 'FALSE'} if with_headers else None
+    headers = {"Sforce-Auto-Assign": "FALSE"} if with_headers else None
 
     result = await sf_type.metadata(headers=headers)
     assert result == {}
@@ -73,19 +71,17 @@ async def test_metadata_with_request_headers(
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("with_headers", (True, False))
-async def test_describe_with_request_headers(
-    with_headers, mock_httpx_client
-):
+async def test_describe_with_request_headers(with_headers, mock_httpx_client):
     """
     Ensure custom headers are used for describe requests
     when passed.
     """
     _, mock_client, inner = mock_httpx_client
-    happy_result = httpx.Response(200, content=b'{}')
+    happy_result = httpx.Response(200, content=b"{}")
     inner(happy_result)
 
     sf_type = _create_sf_type()
-    headers = {'Sforce-Auto-Assign': 'FALSE'} if with_headers else None
+    headers = {"Sforce-Auto-Assign": "FALSE"} if with_headers else None
 
     result = await sf_type.describe(headers=headers)
     assert result == {}
@@ -102,23 +98,19 @@ async def test_describe_with_request_headers(
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("with_headers", (True, False))
-async def test_describe_layout_with_request_headers(
-    with_headers, mock_httpx_client
-):
+async def test_describe_layout_with_request_headers(with_headers, mock_httpx_client):
     """
     Ensure custom headers are used for describe_layout requests
     when passed.
     """
     _, mock_client, inner = mock_httpx_client
-    happy_result = httpx.Response(200, content=b'{}')
+    happy_result = httpx.Response(200, content=b"{}")
     inner(happy_result)
 
     sf_type = _create_sf_type()
-    headers = {'Sforce-Auto-Assign': 'FALSE'} if with_headers else None
+    headers = {"Sforce-Auto-Assign": "FALSE"} if with_headers else None
 
-    result = await sf_type.describe_layout(
-        record_id='444', headers=headers
-    )
+    result = await sf_type.describe_layout(record_id="444", headers=headers)
     assert result == {}
     assert len(mock_client.method_calls) == 1
     call = mock_client.method_calls[0]
@@ -133,24 +125,20 @@ async def test_describe_layout_with_request_headers(
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("with_headers", (True, False))
-async def test_get_with_request_headers(
-    with_headers, mock_httpx_client
-):
+async def test_get_with_request_headers(with_headers, mock_httpx_client):
     """
     Ensure custom headers are used for get requests
     when passed.
     """
     _, mock_client, inner = mock_httpx_client
-    happy_result = httpx.Response(200, content=b'{}')
+    happy_result = httpx.Response(200, content=b"{}")
     inner(happy_result)
 
     sf_type = _create_sf_type()
     headers = None
-    headers = {'Sforce-Auto-Assign': 'FALSE'} if with_headers else None
+    headers = {"Sforce-Auto-Assign": "FALSE"} if with_headers else None
 
-    result = await sf_type.get(
-        record_id='444', headers=headers
-    )
+    result = await sf_type.get(record_id="444", headers=headers)
     assert result == {}
     assert len(mock_client.method_calls) == 1
     call = mock_client.method_calls[0]
@@ -165,24 +153,20 @@ async def test_get_with_request_headers(
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("with_headers", (True, False))
-async def test_get_customid_with_request_headers(
-    with_headers, mock_httpx_client
-):
+async def test_get_customid_with_request_headers(with_headers, mock_httpx_client):
     """
     Ensure custom headers are used for get_by_custom_id requests
     when passed.
     """
     _, mock_client, inner = mock_httpx_client
-    happy_result = httpx.Response(200, content=b'{}')
+    happy_result = httpx.Response(200, content=b"{}")
     inner(happy_result)
 
     sf_type = _create_sf_type()
-    headers = {'Sforce-Auto-Assign': 'FALSE'} if with_headers else None
+    headers = {"Sforce-Auto-Assign": "FALSE"} if with_headers else None
 
     result = await sf_type.get_by_custom_id(
-        custom_id_field='some-field',
-        custom_id='444',
-        headers=headers
+        custom_id_field="some-field", custom_id="444", headers=headers
     )
     assert result == {}
     assert len(mock_client.method_calls) == 1
@@ -198,24 +182,19 @@ async def test_get_customid_with_request_headers(
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("with_headers", (True, False))
-async def test_create_with_request_headers(
-    with_headers, mock_httpx_client
-):
+async def test_create_with_request_headers(with_headers, mock_httpx_client):
     """
     Ensure custom headers are used for create requests
     when passed.
     """
     _, mock_client, inner = mock_httpx_client
-    happy_result = httpx.Response(200, content=b'{}')
+    happy_result = httpx.Response(200, content=b"{}")
     inner(happy_result)
 
     sf_type = _create_sf_type()
-    headers = {'Sforce-Auto-Assign': 'FALSE'} if with_headers else None
+    headers = {"Sforce-Auto-Assign": "FALSE"} if with_headers else None
 
-    result = await sf_type.create(
-        data={'some': 'data'},
-        headers=headers
-    )
+    result = await sf_type.create(data={"some": "data"}, headers=headers)
     assert result == {}
     assert len(mock_client.method_calls) == 1
     call = mock_client.method_calls[0]
@@ -230,12 +209,10 @@ async def test_create_with_request_headers(
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("with_headers,with_raw_response", (
-    (True, False),
-    (True, True),
-    (False, False),
-    (False, True),
-))
+@pytest.mark.parametrize(
+    "with_headers,with_raw_response",
+    ((True, False), (True, True), (False, False), (False, True),),
+)
 async def test_update_with_request_headers(
     with_headers, with_raw_response, mock_httpx_client
 ):
@@ -244,17 +221,17 @@ async def test_update_with_request_headers(
     when passed. Test raw_response kwarg also.
     """
     _, mock_client, inner = mock_httpx_client
-    happy_result = httpx.Response(200, content=b'{}')
+    happy_result = httpx.Response(200, content=b"{}")
     inner(happy_result)
 
     sf_type = _create_sf_type()
-    headers = {'Sforce-Auto-Assign': 'FALSE'} if with_headers else None
+    headers = {"Sforce-Auto-Assign": "FALSE"} if with_headers else None
 
     result = await sf_type.update(
-        'some-case-id',
-        {'some': 'data'},
+        "some-case-id",
+        {"some": "data"},
         headers=headers,
-        raw_response=with_raw_response
+        raw_response=with_raw_response,
     )
     if with_raw_response:
         assert result == happy_result
@@ -273,12 +250,10 @@ async def test_update_with_request_headers(
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("with_headers,with_raw_response", (
-    (True, False),
-    (True, True),
-    (False, False),
-    (False, True),
-))
+@pytest.mark.parametrize(
+    "with_headers,with_raw_response",
+    ((True, False), (True, True), (False, False), (False, True),),
+)
 async def test_upsert_with_request_headers(
     with_headers, with_raw_response, mock_httpx_client
 ):
@@ -287,16 +262,16 @@ async def test_upsert_with_request_headers(
     when passed. Test raw_response kwarg also.
     """
     _, mock_client, inner = mock_httpx_client
-    happy_result = httpx.Response(200, content=b'{}')
+    happy_result = httpx.Response(200, content=b"{}")
     inner(happy_result)
 
     sf_type = _create_sf_type()
-    headers = {'Sforce-Auto-Assign': 'FALSE'} if with_headers else None
+    headers = {"Sforce-Auto-Assign": "FALSE"} if with_headers else None
     result = await sf_type.upsert(
-        'some-case-id',
-        {'some': 'data'},
+        "some-case-id",
+        {"some": "data"},
         headers=headers,
-        raw_response=with_raw_response
+        raw_response=with_raw_response,
     )
     if with_raw_response:
         assert result == happy_result
@@ -315,12 +290,10 @@ async def test_upsert_with_request_headers(
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("with_headers,with_raw_response", (
-    (True, False),
-    (True, True),
-    (False, False),
-    (False, True),
-))
+@pytest.mark.parametrize(
+    "with_headers,with_raw_response",
+    ((True, False), (True, True), (False, False), (False, True),),
+)
 async def test_delete_with_request_headers(
     with_headers, with_raw_response, mock_httpx_client
 ):
@@ -329,15 +302,13 @@ async def test_delete_with_request_headers(
     when passed. Test raw_response kwarg also.
     """
     _, mock_client, inner = mock_httpx_client
-    happy_result = httpx.Response(200, content=b'{}')
+    happy_result = httpx.Response(200, content=b"{}")
     inner(happy_result)
 
     sf_type = _create_sf_type()
-    headers = {'Sforce-Auto-Assign': 'FALSE'} if with_headers else None
+    headers = {"Sforce-Auto-Assign": "FALSE"} if with_headers else None
     result = await sf_type.delete(
-        'some-case-id',
-        headers=headers,
-        raw_response=with_raw_response
+        "some-case-id", headers=headers, raw_response=with_raw_response
     )
     if with_raw_response:
         assert result == happy_result
@@ -356,24 +327,20 @@ async def test_delete_with_request_headers(
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("with_headers", (True, False))
-async def test_deleted_with_request_headers(
-    with_headers, mock_httpx_client
-):
+async def test_deleted_with_request_headers(with_headers, mock_httpx_client):
     """
     Ensure custom headers are used for deleted requests
     when passed.
     """
     _, mock_client, inner = mock_httpx_client
-    happy_result = httpx.Response(200, content=b'{}')
+    happy_result = httpx.Response(200, content=b"{}")
     inner(happy_result)
 
     sf_type = _create_sf_type()
     start = datetime.now()
     end = datetime.now()
-    headers = {'Sforce-Auto-Assign': 'FALSE'} if with_headers else None
-    result = await sf_type.deleted(
-        start, end, headers=headers,
-    )
+    headers = {"Sforce-Auto-Assign": "FALSE"} if with_headers else None
+    result = await sf_type.deleted(start, end, headers=headers,)
     start = date_to_iso8601(start)
     end = date_to_iso8601(end)
     assert result == {}
@@ -390,24 +357,20 @@ async def test_deleted_with_request_headers(
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("with_headers", (True, False))
-async def test_updated_with_request_headers(
-    with_headers, mock_httpx_client
-):
+async def test_updated_with_request_headers(with_headers, mock_httpx_client):
     """
     Ensure custom headers are used for updated requests
     when passed.
     """
     _, mock_client, inner = mock_httpx_client
-    happy_result = httpx.Response(200, content=b'{}')
+    happy_result = httpx.Response(200, content=b"{}")
     inner(happy_result)
 
     sf_type = _create_sf_type()
     start = datetime.now()
     end = datetime.now()
-    headers = {'Sforce-Auto-Assign': 'FALSE'} if with_headers else None
-    result = await sf_type.updated(
-        start, end, headers=headers,
-    )
+    headers = {"Sforce-Auto-Assign": "FALSE"} if with_headers else None
+    result = await sf_type.updated(start, end, headers=headers,)
     start = date_to_iso8601(start)
     end = date_to_iso8601(end)
     assert result == {}
@@ -420,6 +383,7 @@ async def test_updated_with_request_headers(
         assert call[2]["headers"]["Sforce-Auto-Assign"] == "FALSE"
     else:
         assert "Sforce-Auto-Assign" not in call[2]["headers"]
+
 
 # # # # # # # # # # # # # # # # # # # # # #
 #
@@ -434,18 +398,15 @@ async def test_build_async_with_session_success(constants, mock_httpx_client):
     Test the builder function and pass a custom session
     """
     _, mock_client, inner = mock_httpx_client
-    happy_result = httpx.Response(
-        200,
-        content=constants["LOGIN_RESPONSE_SUCCESS"]
-    )
+    happy_result = httpx.Response(200, content=constants["LOGIN_RESPONSE_SUCCESS"])
     inner(happy_result)
     mock_client.custom_session_attrib = "X-1-2-3"
 
     client = await build_async_salesforce_client(
         session=mock_client,
-        username='foo@bar.com',
-        password='password',
-        security_token='token'
+        username="foo@bar.com",
+        password="password",
+        security_token="token",
     )
     assert isinstance(client, AsyncSalesforce)
     assert constants["SESSION_ID"] == client.session_id
@@ -454,9 +415,7 @@ async def test_build_async_with_session_success(constants, mock_httpx_client):
     assert len(mock_client.method_calls) == 1
     call = mock_client.method_calls[0]
     assert call[0] == "post"
-    assert call[1][0].startswith(
-        "https://login.salesforce.com/services/Soap/u/"
-    )
+    assert call[1][0].startswith("https://login.salesforce.com/services/Soap/u/")
     assert "SOAPAction" in call[2]["headers"]
     assert call[2]["headers"]["SOAPAction"] == "login"
 
@@ -465,12 +424,9 @@ def test_client_custom_version():
     """
     Check custom version appears in URL
     """
-    expected_version = '4.2'
-    client = AsyncSalesforce(
-        session=mock.AsyncMock(),
-        version=expected_version
-    )
-    assert client.base_url.split('/')[-2] == 'v%s' % expected_version
+    expected_version = "4.2"
+    client = AsyncSalesforce(session=mock.AsyncMock(), version=expected_version)
+    assert client.base_url.split("/")[-2] == "v%s" % expected_version
 
 
 def test_custom_session_to_sftype(constants):
@@ -479,10 +435,7 @@ def test_custom_session_to_sftype(constants):
     """
     mock_sesh = mock.AsyncMock()
     mock_sesh.custom_session_attrib = "X-1-2-3"
-    client = AsyncSalesforce(
-        session=mock_sesh,
-        session_id=constants["SESSION_ID"],
-    )
+    client = AsyncSalesforce(session=mock_sesh, session_id=constants["SESSION_ID"],)
     assert client.session == client.Contact.session == mock_sesh
     assert client.Contact.session.custom_session_attrib == "X-1-2-3"
 
@@ -493,8 +446,7 @@ def test_proxies_inherited_by_default(constants):
     Check session gets passed to AsyncSFType and proxies are inherited
     """
     client = AsyncSalesforce(
-        session_id=constants["SESSION_ID"],
-        proxies=constants["PROXIES"]
+        session_id=constants["SESSION_ID"], proxies=constants["PROXIES"]
     )
     # proxies arg should be ignored in this case.
     # no_proxies_client = AsyncSalesforce(
@@ -518,11 +470,11 @@ async def test_api_usage_simple(mock_httpx_client, sf_client):
     happy_result = httpx.Response(
         200,
         content='{"example": 1}',
-        headers={"Sforce-Limit-Info": "api-usage=18/5000"}
+        headers={"Sforce-Limit-Info": "api-usage=18/5000"},
     )
     inner(happy_result)
-    await sf_client.query('q')
-    assert sf_client.api_usage == {'api-usage': Usage(18, 5000)}
+    await sf_client.query("q")
+    assert sf_client.api_usage == {"api-usage": Usage(18, 5000)}
 
 
 @pytest.mark.asyncio
@@ -533,65 +485,55 @@ async def test_api_usage_per_app(mock_httpx_client, sf_client):
     _, _, inner = mock_httpx_client
     pau = "api-usage=25/5000; per-app-api-usage=17/250(appName=sample-app)"
     happy_result = httpx.Response(
-        200,
-        content='{"example": 1}',
-        headers={"Sforce-Limit-Info": pau}
+        200, content='{"example": 1}', headers={"Sforce-Limit-Info": pau}
     )
     inner(happy_result)
-    await sf_client.query('q')
+    await sf_client.query("q")
     expected = {
-        'api-usage': Usage(25, 5000),
-        'per-app-api-usage': PerAppUsage(17, 250, 'sample-app')
+        "api-usage": Usage(25, 5000),
+        "per-app-api-usage": PerAppUsage(17, 250, "sample-app"),
     }
     assert sf_client.api_usage == expected
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("include_deleted,expected_url", (
-    (True, "https://localhost/queryAll/"),
-    (False, "https://localhost/query/"),
-))
+@pytest.mark.parametrize(
+    "include_deleted,expected_url",
+    ((True, "https://localhost/queryAll/"), (False, "https://localhost/query/"),),
+)
 async def test_query(
     include_deleted, expected_url, mock_httpx_client, sf_client,
 ):
     """Test querying generates the expected request"""
     _, mock_client, inner = mock_httpx_client
-    happy_result = httpx.Response(
-        200,
-        content="{}"
-    )
+    happy_result = httpx.Response(200, content="{}")
     inner(happy_result)
-    await sf_client.query(
-        'SELECT ID FROM Account',
-        include_deleted=include_deleted
-    )
+    await sf_client.query("SELECT ID FROM Account", include_deleted=include_deleted)
     assert len(mock_client.method_calls) == 1
     call = mock_client.method_calls[0]
     assert call[1][0] == "GET"
     assert call[1][1] == expected_url
     assert call[2]["headers"] == {}
-    assert call[2]["params"] == {'q': 'SELECT ID FROM Account'}
+    assert call[2]["params"] == {"q": "SELECT ID FROM Account"}
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("include_deleted,expected_url", (
-    (True, "https://localhost/queryAll/next-records-id"),
-    (False, "https://localhost/query/next-records-id"),
-))
+@pytest.mark.parametrize(
+    "include_deleted,expected_url",
+    (
+        (True, "https://localhost/queryAll/next-records-id"),
+        (False, "https://localhost/query/next-records-id"),
+    ),
+)
 async def test_query_more_id_not_url(
     include_deleted, expected_url, mock_httpx_client, sf_client,
 ):
     """Test querying generates the expected request"""
     _, mock_client, inner = mock_httpx_client
-    happy_result = httpx.Response(
-        200,
-        content="{}"
-    )
+    happy_result = httpx.Response(200, content="{}")
     inner(happy_result)
     await sf_client.query_more(
-        'next-records-id',
-        include_deleted=include_deleted,
-        identifier_is_url=False
+        "next-records-id", include_deleted=include_deleted, identifier_is_url=False
     )
     assert len(mock_client.method_calls) == 1
     call = mock_client.method_calls[0]
@@ -611,28 +553,18 @@ async def test_query_all_iter(
         "records": [{"ID": "1"}],
         "done": False,
         "nextRecordsUrl": "https://example.com/query/next-records-id",
-        "totalSize": 2
+        "totalSize": 2,
     }
-    body2 = {
-        "records": [{"ID": "2"}],
-        "done": True,
-        "totalSize": 2
-    }
+    body2 = {"records": [{"ID": "2"}], "done": True, "totalSize": 2}
     responses = [
-        httpx.Response(
-            200,
-            content=json.dumps(body1)
-        ),
-        httpx.Response(
-            200,
-            content=json.dumps(body2)
-        ),
+        httpx.Response(200, content=json.dumps(body1)),
+        httpx.Response(200, content=json.dumps(body2)),
     ]
     mock_client.request.side_effect = mock.AsyncMock(side_effect=responses)
-    expected = [OrderedDict([('ID', '1')]), OrderedDict([('ID', '2')])]
+    expected = [OrderedDict([("ID", "1")]), OrderedDict([("ID", "2")])]
 
     # This should return an Async Generator: collect responses and compare
-    result = sf_client.query_all_iter('SELECT ID FROM Account')
+    result = sf_client.query_all_iter("SELECT ID FROM Account")
     collection = []
     async for item in result:
         collection.append(item)
@@ -651,32 +583,22 @@ async def test_query_all(
         "records": [{"ID": "1"}],
         "done": False,
         "nextRecordsUrl": "https://example.com/query/next-records-id",
-        "totalSize": 2
+        "totalSize": 2,
     }
-    body2 = {
-        "records": [{"ID": "2"}],
-        "done": True,
-        "totalSize": 2
-    }
+    body2 = {"records": [{"ID": "2"}], "done": True, "totalSize": 2}
     responses = [
-        httpx.Response(
-            200,
-            content=json.dumps(body1)
-        ),
-        httpx.Response(
-            200,
-            content=json.dumps(body2)
-        ),
+        httpx.Response(200, content=json.dumps(body1)),
+        httpx.Response(200, content=json.dumps(body2)),
     ]
     mock_client.request.side_effect = mock.AsyncMock(side_effect=responses)
     expected = {
         "totalSize": 2,
-        "records": [OrderedDict([('ID', '1')]), OrderedDict([('ID', '2')])],
-        "done": True
+        "records": [OrderedDict([("ID", "1")]), OrderedDict([("ID", "2")])],
+        "done": True,
     }
 
     # This should eagerly pull all results from all pages
-    result = await sf_client.query_all('SELECT ID FROM Account')
+    result = await sf_client.query_all("SELECT ID FROM Account")
     assert result == expected
     assert len(mock_client.method_calls) == 2
 
@@ -688,8 +610,7 @@ async def test_api_limits(
     """Test method for getting Salesforce organization limits"""
     _, mock_client, inner = mock_httpx_client
     happy_result = httpx.Response(
-        200,
-        content=json.dumps(constants["ORGANIZATION_LIMITS_RESPONSE"])
+        200, content=json.dumps(constants["ORGANIZATION_LIMITS_RESPONSE"])
     )
     inner(happy_result)
     result = await sf_client.limits()
@@ -705,24 +626,23 @@ async def test_md_deploy_success(
     mock_httpx_client, sf_client,
 ):
     """Test method for metadata deployment"""
-    mock_response = '<?xml version="1.0" ' \
-                    'encoding="UTF-8"?><soapenv:Envelope ' \
-                    'xmlns:soapenv="http://schemas.xmlsoap.org/soap' \
-                    '/envelope/" ' \
-                    'xmlns="http://soap.sforce.com/2006/04/metadata' \
-                    '"><soapenv:Body><deployResponse><result><done' \
-                    '>false</done><id>0Af3B00001CMyfASAT</id><state' \
-                    '>Queued</state></result></deployResponse></soapenv' \
-                    ':Body></soapenv:Envelope>'
+    mock_response = (
+        '<?xml version="1.0" '
+        'encoding="UTF-8"?><soapenv:Envelope '
+        'xmlns:soapenv="http://schemas.xmlsoap.org/soap'
+        '/envelope/" '
+        'xmlns="http://soap.sforce.com/2006/04/metadata'
+        '"><soapenv:Body><deployResponse><result><done'
+        ">false</done><id>0Af3B00001CMyfASAT</id><state"
+        ">Queued</state></result></deployResponse></soapenv"
+        ":Body></soapenv:Envelope>"
+    )
 
     _, mock_client, inner = mock_httpx_client
-    happy_result = httpx.Response(
-        200,
-        content=mock_response
-    )
+    happy_result = httpx.Response(200, content=mock_response)
     inner(happy_result)
-    async with aiofiles.tempfile.NamedTemporaryFile('wb+') as fl:
-        await fl.write(b'Line1\n Line2')
+    async with aiofiles.tempfile.NamedTemporaryFile("wb+") as fl:
+        await fl.write(b"Line1\n Line2")
         await fl.seek(0)
         result = await sf_client.deploy(fl.name, sandbox=False)
     assert result.get("asyncId") == "0Af3B00001CMyfASAT"
@@ -743,14 +663,15 @@ async def test_md_deploy_failed_status_code(
     bad_result = httpx.Response(
         2599,
         request=httpx.Request("POST", f"{sf_client.metadata_url}deployRequest"),
-        content=b"Unrecognized Error"
+        content=b"Unrecognized Error",
     )
     inner(bad_result)
-    async with aiofiles.tempfile.NamedTemporaryFile('wb+') as fl:
-        await fl.write(b'Line1\n Line2')
+    async with aiofiles.tempfile.NamedTemporaryFile("wb+") as fl:
+        await fl.write(b"Line1\n Line2")
         await fl.seek(0)
         with pytest.raises(SalesforceGeneralError):
             await sf_client.deploy(fl.name, sandbox=False)
+
 
 DEPLOY_PENDING = (
     '<?xml version="1.0" '
@@ -759,26 +680,26 @@ DEPLOY_PENDING = (
     '/envelope/" '
     'xmlns="http://soap.sforce.com/2006/04/metadata'
     '"><soapenv:Body><checkDeployStatusResponse><result'
-    '><checkOnly>true</checkOnly><createdBy'
-    '>0053D0000052Xaq</createdBy><createdByName>User '
-    'User</createdByName><createdDate>2020-10-28T15:38:34'
-    '.000Z</createdDate><details><runTestResult'
-    '><numFailures>0</numFailures><numTestsRun>0'
-    '</numTestsRun><totalTime>0.0</totalTime'
-    '></runTestResult></details><done>false</done><id'
-    '>0Af3D00001NViC1SAL</id><ignoreWarnings>false'
-    '</ignoreWarnings><lastModifiedDate>2020-10-28T15:38'
-    ':34.000Z</lastModifiedDate><numberComponentErrors>0'
-    '</numberComponentErrors><numberComponentsDeployed>0'
-    '</numberComponentsDeployed><numberComponentsTotal>0'
-    '</numberComponentsTotal><numberTestErrors>0'
-    '</numberTestErrors><numberTestsCompleted>0'
-    '</numberTestsCompleted><numberTestsTotal>0'
-    '</numberTestsTotal><rollbackOnError>true'
-    '</rollbackOnError><runTestsEnabled>false'
-    '</runTestsEnabled><status>Pending</status><success'
-    '>false</success></result></checkDeployStatusResponse'
-    '></soapenv:Body></soapenv:Envelope>'
+    "><checkOnly>true</checkOnly><createdBy"
+    ">0053D0000052Xaq</createdBy><createdByName>User "
+    "User</createdByName><createdDate>2020-10-28T15:38:34"
+    ".000Z</createdDate><details><runTestResult"
+    "><numFailures>0</numFailures><numTestsRun>0"
+    "</numTestsRun><totalTime>0.0</totalTime"
+    "></runTestResult></details><done>false</done><id"
+    ">0Af3D00001NViC1SAL</id><ignoreWarnings>false"
+    "</ignoreWarnings><lastModifiedDate>2020-10-28T15:38"
+    ":34.000Z</lastModifiedDate><numberComponentErrors>0"
+    "</numberComponentErrors><numberComponentsDeployed>0"
+    "</numberComponentsDeployed><numberComponentsTotal>0"
+    "</numberComponentsTotal><numberTestErrors>0"
+    "</numberTestErrors><numberTestsCompleted>0"
+    "</numberTestsCompleted><numberTestsTotal>0"
+    "</numberTestsTotal><rollbackOnError>true"
+    "</rollbackOnError><runTestsEnabled>false"
+    "</runTestsEnabled><status>Pending</status><success"
+    ">false</success></result></checkDeployStatusResponse"
+    "></soapenv:Body></soapenv:Envelope>"
 )
 
 DEPLOY_SUCCESS = (
@@ -788,51 +709,51 @@ DEPLOY_SUCCESS = (
     '/envelope/" '
     'xmlns="http://soap.sforce.com/2006/04/metadata'
     '"><soapenv:Body><checkDeployStatusResponse><result'
-    '><checkOnly>false</checkOnly><completedDate>2020-10'
-    '-28T13:33:29.000Z</completedDate><createdBy'
-    '>0053D0000052Xaq</createdBy><createdByName>User '
-    'User</createdByName><createdDate>2020-10-28T13:33:25'
-    '.000Z</createdDate><details><componentSuccesses'
-    '><changed>true</changed><componentType>ApexSettings'
-    '</componentType><created>false</created><createdDate'
-    '>2020-10-28T13:33:29.000Z</createdDate><deleted'
-    '>false</deleted><fileName>shape/settings/Apex'
-    '.settings</fileName><fullName>Apex</fullName'
-    '><success>true</success></componentSuccesses'
-    '><componentSuccesses><changed>true</changed'
-    '><componentType>ChatterSettings</componentType'
-    '><created>false</created><createdDate>2020-10-28T13'
-    ':33:29.000Z</createdDate><deleted>false</deleted'
-    '><fileName>shape/settings/Chatter.settings</fileName'
-    '><fullName>Chatter</fullName><success>true</success'
-    '></componentSuccesses><componentSuccesses><changed'
-    '>true</changed><componentType></componentType'
-    '><created>false</created><createdDate>2020-10-28T13'
-    ':33:29.000Z</createdDate><deleted>false</deleted'
-    '><fileName>shape/package.xml</fileName><fullName'
-    '>package.xml</fullName><success>true</success'
-    '></componentSuccesses><componentSuccesses><changed'
-    '>true</changed><componentType>LightningExperienceSettings'
-    '</componentType><created>false</created><createdDate>'
-    '2020-10-28T13:33:29.000Z</createdDate><deleted>false'
-    '</deleted><fileName>shape/settings/LightningExperience.'
-    'settings</fileName><fullName>LightningExperience</fullName>'
-    '<success>true</success></componentSuccesses><component'
-    'Successes><changed>true</changed><componentType>LanguageSettings'
-    '</componentType><created>false</created><createdDate>'
-    '2020-10-28T13:33:29.000Z</createdDate><deleted>false</deleted>'
-    '<fileName>shape/settings/Language.settings</fileName>'
-    '<fullName>Language</fullName><success>true</success>'
-    '</componentSuccesses><runTestResult><numFailures>0</numFailures>'
-    '<numTestsRun>0</numTestsRun><totalTime>0.0</totalTime>'
-    '</runTestResult></details><done>true</done><id>0Af3D00001NVCnwSAH'
-    '</id><ignoreWarnings>false</ignoreWarnings><lastModifiedDate>'
-    '2020-10-28T13:33:29.000Z</lastModifiedDate>'
-    '<numberComponentErrors>0</numberComponentErrors>'
-    '<numberComponentsDeployed>4</numberComponentsDeployed>'
-    '<numberComponentsTotal>4</numberComponentsTotal>'
-    '<numberTestErrors>0</numberTestErrors><numberTestsCompleted>'
-    '0</numberTestsCompleted><numberTestsTotal>0</numberTestsTotal><rollbackOnError>true</rollbackOnError><runTestsEnabled>false</runTestsEnabled><startDate>2020-10-28T13:33:26.000Z</startDate><status>Succeeded</status><success>true</success></result></checkDeployStatusResponse></soapenv:Body></soapenv:Envelope>'
+    "><checkOnly>false</checkOnly><completedDate>2020-10"
+    "-28T13:33:29.000Z</completedDate><createdBy"
+    ">0053D0000052Xaq</createdBy><createdByName>User "
+    "User</createdByName><createdDate>2020-10-28T13:33:25"
+    ".000Z</createdDate><details><componentSuccesses"
+    "><changed>true</changed><componentType>ApexSettings"
+    "</componentType><created>false</created><createdDate"
+    ">2020-10-28T13:33:29.000Z</createdDate><deleted"
+    ">false</deleted><fileName>shape/settings/Apex"
+    ".settings</fileName><fullName>Apex</fullName"
+    "><success>true</success></componentSuccesses"
+    "><componentSuccesses><changed>true</changed"
+    "><componentType>ChatterSettings</componentType"
+    "><created>false</created><createdDate>2020-10-28T13"
+    ":33:29.000Z</createdDate><deleted>false</deleted"
+    "><fileName>shape/settings/Chatter.settings</fileName"
+    "><fullName>Chatter</fullName><success>true</success"
+    "></componentSuccesses><componentSuccesses><changed"
+    ">true</changed><componentType></componentType"
+    "><created>false</created><createdDate>2020-10-28T13"
+    ":33:29.000Z</createdDate><deleted>false</deleted"
+    "><fileName>shape/package.xml</fileName><fullName"
+    ">package.xml</fullName><success>true</success"
+    "></componentSuccesses><componentSuccesses><changed"
+    ">true</changed><componentType>LightningExperienceSettings"
+    "</componentType><created>false</created><createdDate>"
+    "2020-10-28T13:33:29.000Z</createdDate><deleted>false"
+    "</deleted><fileName>shape/settings/LightningExperience."
+    "settings</fileName><fullName>LightningExperience</fullName>"
+    "<success>true</success></componentSuccesses><component"
+    "Successes><changed>true</changed><componentType>LanguageSettings"
+    "</componentType><created>false</created><createdDate>"
+    "2020-10-28T13:33:29.000Z</createdDate><deleted>false</deleted>"
+    "<fileName>shape/settings/Language.settings</fileName>"
+    "<fullName>Language</fullName><success>true</success>"
+    "</componentSuccesses><runTestResult><numFailures>0</numFailures>"
+    "<numTestsRun>0</numTestsRun><totalTime>0.0</totalTime>"
+    "</runTestResult></details><done>true</done><id>0Af3D00001NVCnwSAH"
+    "</id><ignoreWarnings>false</ignoreWarnings><lastModifiedDate>"
+    "2020-10-28T13:33:29.000Z</lastModifiedDate>"
+    "<numberComponentErrors>0</numberComponentErrors>"
+    "<numberComponentsDeployed>4</numberComponentsDeployed>"
+    "<numberComponentsTotal>4</numberComponentsTotal>"
+    "<numberTestErrors>0</numberTestErrors><numberTestsCompleted>"
+    "0</numberTestsCompleted><numberTestsTotal>0</numberTestsTotal><rollbackOnError>true</rollbackOnError><runTestsEnabled>false</runTestsEnabled><startDate>2020-10-28T13:33:26.000Z</startDate><status>Succeeded</status><success>true</success></result></checkDeployStatusResponse></soapenv:Body></soapenv:Envelope>"
 )
 DEPLOY_PAYLOAD_ERROR = (
     '<?xml version="1.0" '
@@ -841,27 +762,27 @@ DEPLOY_PAYLOAD_ERROR = (
     '/envelope/" '
     'xmlns="http://soap.sforce.com/2006/04/metadata'
     '"><soapenv:Body><checkDeployStatusResponse><result'
-    '><checkOnly>true</checkOnly><completedDate>2020-10'
-    '-28T13:37:48.000Z</completedDate><createdBy'
-    '>0053D0000052Xaq</createdBy><createdByName>User '
-    'User</createdByName><createdDate>2020-10-28T13:37:46'
-    '.000Z</createdDate><details><componentFailures'
-    '><changed>false</changed><componentType'
-    '></componentType><created>false</created'
-    '><createdDate>2020-10-28T13:37:47.000Z</createdDate'
-    '><deleted>false</deleted><fileName>package.xml'
-    '</fileName><fullName>package.xml</fullName><problem'
-    '>No package.xml '
-    'found</problem><problemType>Error</problemType'
-    '><success>false</success></componentFailures'
-    '><runTestResult><numFailures>0</numFailures'
-    '><numTestsRun>0</numTestsRun><totalTime>0.0'
-    '</totalTime></runTestResult></details><done>true'
-    '</done><id>0Af3D00001NVD0TSAX</id><ignoreWarnings'
-    '>false</ignoreWarnings><lastModifiedDate>2020-10'
-    '-28T13:37:48.000Z</lastModifiedDate'
-    '><numberComponentErrors>0</numberComponentErrors'
-    '><numberComponentsDeployed>0</numberComponentsDeployed><numberComponentsTotal>0</numberComponentsTotal><numberTestErrors>0</numberTestErrors><numberTestsCompleted>0</numberTestsCompleted><numberTestsTotal>0</numberTestsTotal><rollbackOnError>true</rollbackOnError><runTestsEnabled>false</runTestsEnabled><startDate>2020-10-28T13:37:47.000Z</startDate><status>Failed</status><success>false</success></result></checkDeployStatusResponse></soapenv:Body></soapenv:Envelope>'
+    "><checkOnly>true</checkOnly><completedDate>2020-10"
+    "-28T13:37:48.000Z</completedDate><createdBy"
+    ">0053D0000052Xaq</createdBy><createdByName>User "
+    "User</createdByName><createdDate>2020-10-28T13:37:46"
+    ".000Z</createdDate><details><componentFailures"
+    "><changed>false</changed><componentType"
+    "></componentType><created>false</created"
+    "><createdDate>2020-10-28T13:37:47.000Z</createdDate"
+    "><deleted>false</deleted><fileName>package.xml"
+    "</fileName><fullName>package.xml</fullName><problem"
+    ">No package.xml "
+    "found</problem><problemType>Error</problemType"
+    "><success>false</success></componentFailures"
+    "><runTestResult><numFailures>0</numFailures"
+    "><numTestsRun>0</numTestsRun><totalTime>0.0"
+    "</totalTime></runTestResult></details><done>true"
+    "</done><id>0Af3D00001NVD0TSAX</id><ignoreWarnings"
+    ">false</ignoreWarnings><lastModifiedDate>2020-10"
+    "-28T13:37:48.000Z</lastModifiedDate"
+    "><numberComponentErrors>0</numberComponentErrors"
+    "><numberComponentsDeployed>0</numberComponentsDeployed><numberComponentsTotal>0</numberComponentsTotal><numberTestErrors>0</numberTestErrors><numberTestsCompleted>0</numberTestsCompleted><numberTestsTotal>0</numberTestsTotal><rollbackOnError>true</rollbackOnError><runTestsEnabled>false</runTestsEnabled><startDate>2020-10-28T13:37:47.000Z</startDate><status>Failed</status><success>false</success></result></checkDeployStatusResponse></soapenv:Body></soapenv:Envelope>"
 )
 
 DEPLOY_IN_PROGRESS = (
@@ -871,27 +792,27 @@ DEPLOY_IN_PROGRESS = (
     '/envelope/" '
     'xmlns="http://soap.sforce.com/2006/04/metadata'
     '"><soapenv:Body><checkDeployStatusResponse><result'
-    '><checkOnly>false</checkOnly><createdBy'
-    '>0053D0000052Xaq</createdBy><createdByName>User '
-    'User</createdByName><createdDate>2020-10-28T17:24:30'
-    '.000Z</createdDate><details><runTestResult'
-    '><numFailures>0</numFailures><numTestsRun>0'
-    '</numTestsRun><totalTime>0.0</totalTime'
-    '></runTestResult></details><done>false</done><id'
-    '>0Af3D00001NW8mnSAD</id><ignoreWarnings>false'
-    '</ignoreWarnings><lastModifiedDate>2020-10-28T17:37'
-    ':08.000Z</lastModifiedDate><numberComponentErrors>0'
-    '</numberComponentErrors><numberComponentsDeployed>2'
-    '</numberComponentsDeployed><numberComponentsTotal>3'
-    '</numberComponentsTotal><numberTestErrors>0'
-    '</numberTestErrors><numberTestsCompleted>0'
-    '</numberTestsCompleted><numberTestsTotal>0'
-    '</numberTestsTotal><rollbackOnError>true'
-    '</rollbackOnError><runTestsEnabled>false'
-    '</runTestsEnabled><startDate>2020-10-28T17:24:30'
-    '.000Z</startDate><status>InProgress</status><success'
-    '>false</success></result></checkDeployStatusResponse'
-    '></soapenv:Body></soapenv:Envelope>'
+    "><checkOnly>false</checkOnly><createdBy"
+    ">0053D0000052Xaq</createdBy><createdByName>User "
+    "User</createdByName><createdDate>2020-10-28T17:24:30"
+    ".000Z</createdDate><details><runTestResult"
+    "><numFailures>0</numFailures><numTestsRun>0"
+    "</numTestsRun><totalTime>0.0</totalTime"
+    "></runTestResult></details><done>false</done><id"
+    ">0Af3D00001NW8mnSAD</id><ignoreWarnings>false"
+    "</ignoreWarnings><lastModifiedDate>2020-10-28T17:37"
+    ":08.000Z</lastModifiedDate><numberComponentErrors>0"
+    "</numberComponentErrors><numberComponentsDeployed>2"
+    "</numberComponentsDeployed><numberComponentsTotal>3"
+    "</numberComponentsTotal><numberTestErrors>0"
+    "</numberTestErrors><numberTestsCompleted>0"
+    "</numberTestsCompleted><numberTestsTotal>0"
+    "</numberTestsTotal><rollbackOnError>true"
+    "</rollbackOnError><runTestsEnabled>false"
+    "</runTestsEnabled><startDate>2020-10-28T17:24:30"
+    ".000Z</startDate><status>InProgress</status><success"
+    ">false</success></result></checkDeployStatusResponse"
+    "></soapenv:Body></soapenv:Envelope>"
 )
 
 
@@ -901,26 +822,23 @@ async def test_check_status_pending(
 ):
     """Test method for metadata deployment"""
     _, mock_client, inner = mock_httpx_client
-    happy_result = httpx.Response(
-        200,
-        content=DEPLOY_PENDING
-    )
+    happy_result = httpx.Response(200, content=DEPLOY_PENDING)
     inner(happy_result)
 
     result = await sf_client.checkDeployStatus("abdcefg", sandbox=False)
     assert result.get("state") == "Pending"
     assert result.get("state_detail") is None
     assert result.get("deployment_detail") == {
-        'total_count': '0',
-        'failed_count': '0',
-        'deployed_count': '0',
-        'errors': []
+        "total_count": "0",
+        "failed_count": "0",
+        "deployed_count": "0",
+        "errors": [],
     }
     assert result.get("unit_test_detail") == {
-        'total_count': '0',
-        'failed_count': '0',
-        'completed_count': '0',
-        'errors': []
+        "total_count": "0",
+        "failed_count": "0",
+        "completed_count": "0",
+        "errors": [],
     }
 
     assert len(mock_client.method_calls) == 1
@@ -935,28 +853,24 @@ async def test_check_status_success(
 ):
     """Test method for metadata deployment"""
 
-
     _, mock_client, inner = mock_httpx_client
-    happy_result = httpx.Response(
-        200,
-        content=DEPLOY_SUCCESS
-    )
+    happy_result = httpx.Response(200, content=DEPLOY_SUCCESS)
     inner(happy_result)
 
     result = await sf_client.checkDeployStatus("abdcefg", sandbox=False)
     assert result.get("state") == "Succeeded"
     assert result.get("state_detail") is None
     assert result.get("deployment_detail") == {
-        'total_count': '4',
-        'failed_count': '0',
-        'deployed_count': '4',
-        'errors': []
+        "total_count": "4",
+        "failed_count": "0",
+        "deployed_count": "4",
+        "errors": [],
     }
     assert result.get("unit_test_detail") == {
-        'total_count': '0',
-        'failed_count': '0',
-        'completed_count': '0',
-        'errors': []
+        "total_count": "0",
+        "failed_count": "0",
+        "completed_count": "0",
+        "errors": [],
     }
 
     assert len(mock_client.method_calls) == 1
@@ -971,31 +885,30 @@ async def test_check_status_payload_error(
 ):
     """Test method for metadata deployment"""
     _, mock_client, inner = mock_httpx_client
-    happy_result = httpx.Response(
-        200,
-        content=DEPLOY_PAYLOAD_ERROR
-    )
+    happy_result = httpx.Response(200, content=DEPLOY_PAYLOAD_ERROR)
     inner(happy_result)
 
     result = await sf_client.checkDeployStatus("abdcefg", sandbox=False)
     assert result.get("state") == "Failed"
     assert result.get("state_detail") is None
     assert result.get("deployment_detail") == {
-        'total_count': '0',
-        'failed_count': '0',
-        'deployed_count': '0',
-        'errors': [
+        "total_count": "0",
+        "failed_count": "0",
+        "deployed_count": "0",
+        "errors": [
             {
-                'type': None, 'file': 'package.xml',
-                'status': 'Error', 'message': 'No package.xml found'
+                "type": None,
+                "file": "package.xml",
+                "status": "Error",
+                "message": "No package.xml found",
             }
-        ]
+        ],
     }
     assert result.get("unit_test_detail") == {
-        'total_count': '0',
-        'failed_count': '0',
-        'completed_count': '0',
-        'errors': []
+        "total_count": "0",
+        "failed_count": "0",
+        "completed_count": "0",
+        "errors": [],
     }
     assert len(mock_client.method_calls) == 1
     call = mock_client.method_calls[0]
@@ -1009,26 +922,23 @@ async def test_check_status_in_progress(
 ):
     """Test method for metadata deployment"""
     _, mock_client, inner = mock_httpx_client
-    happy_result = httpx.Response(
-        200,
-        content=DEPLOY_IN_PROGRESS
-    )
+    happy_result = httpx.Response(200, content=DEPLOY_IN_PROGRESS)
     inner(happy_result)
 
     result = await sf_client.checkDeployStatus("abdcefg", sandbox=False)
     assert result.get("state") == "InProgress"
     assert result.get("state_detail") is None
     assert result.get("deployment_detail") == {
-        'total_count': '3',
-        'failed_count': '0',
-        'deployed_count': '2',
-        'errors': []
+        "total_count": "3",
+        "failed_count": "0",
+        "deployed_count": "2",
+        "errors": [],
     }
     assert result.get("unit_test_detail") == {
-        'total_count': '0',
-        'failed_count': '0',
-        'completed_count': '0',
-        'errors': []
+        "total_count": "0",
+        "failed_count": "0",
+        "completed_count": "0",
+        "errors": [],
     }
 
     assert len(mock_client.method_calls) == 1

--- a/simple_salesforce/tests/test_aio/test_api.py
+++ b/simple_salesforce/tests/test_aio/test_api.py
@@ -1,0 +1,1051 @@
+# pylint: disable-msg=C0302
+# pylint: disable=redefined-outer-name
+"""Tests for api.py"""
+from collections import OrderedDict
+from datetime import datetime
+import json
+from unittest import mock
+
+import aiofiles
+import httpx
+import pytest
+
+from simple_salesforce.api import PerAppUsage, Usage
+from simple_salesforce.aio.api import (
+    build_async_salesforce_client, AsyncSalesforce, SFType
+)
+from simple_salesforce.exceptions import SalesforceGeneralError
+from simple_salesforce.util import date_to_iso8601
+
+
+DEFAULT_URL = "https://my.salesforce.com/services/data/v42.0/sobjects/{}"
+CASE_URL = DEFAULT_URL.format("Case")
+
+# # # # # # # # # # # # # # # # # # # # # #
+#
+# SFType Tests
+#
+# # # # # # # # # # # # # # # # # # # # # #
+
+
+def _create_sf_type(
+        object_name='Case',
+        session_id='5',
+        sf_instance='my.salesforce.com'
+        ):
+    """Creates SFType instances"""
+    return SFType(
+        object_name=object_name,
+        session_id=session_id,
+        sf_instance=sf_instance,
+        session=httpx.AsyncClient()
+        )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("with_headers", (True, False))
+async def test_metadata_with_request_headers(
+    with_headers, mock_httpx_client
+):
+    """
+    Ensure custom headers are used for metadata requests
+    when passed.
+    """
+    _, mock_client, inner = mock_httpx_client
+    happy_result = httpx.Response(200, content=b'{}')
+    inner(happy_result)
+
+    sf_type = _create_sf_type()
+    headers = {'Sforce-Auto-Assign': 'FALSE'} if with_headers else None
+
+    result = await sf_type.metadata(headers=headers)
+    assert result == {}
+    assert len(mock_client.method_calls) == 1
+    call = mock_client.method_calls[0]
+    assert call[1][0] == "GET"
+    assert call[1][1] == f"{CASE_URL}/"
+    if with_headers:
+        assert "Sforce-Auto-Assign" in call[2]["headers"]
+        assert call[2]["headers"]["Sforce-Auto-Assign"] == "FALSE"
+    else:
+        assert "Sforce-Auto-Assign" not in call[2]["headers"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("with_headers", (True, False))
+async def test_describe_with_request_headers(
+    with_headers, mock_httpx_client
+):
+    """
+    Ensure custom headers are used for describe requests
+    when passed.
+    """
+    _, mock_client, inner = mock_httpx_client
+    happy_result = httpx.Response(200, content=b'{}')
+    inner(happy_result)
+
+    sf_type = _create_sf_type()
+    headers = {'Sforce-Auto-Assign': 'FALSE'} if with_headers else None
+
+    result = await sf_type.describe(headers=headers)
+    assert result == {}
+    assert len(mock_client.method_calls) == 1
+    call = mock_client.method_calls[0]
+    assert call[1][0] == "GET"
+    assert call[1][1] == f"{CASE_URL}/describe"
+    if with_headers:
+        assert "Sforce-Auto-Assign" in call[2]["headers"]
+        assert call[2]["headers"]["Sforce-Auto-Assign"] == "FALSE"
+    else:
+        assert "Sforce-Auto-Assign" not in call[2]["headers"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("with_headers", (True, False))
+async def test_describe_layout_with_request_headers(
+    with_headers, mock_httpx_client
+):
+    """
+    Ensure custom headers are used for describe_layout requests
+    when passed.
+    """
+    _, mock_client, inner = mock_httpx_client
+    happy_result = httpx.Response(200, content=b'{}')
+    inner(happy_result)
+
+    sf_type = _create_sf_type()
+    headers = {'Sforce-Auto-Assign': 'FALSE'} if with_headers else None
+
+    result = await sf_type.describe_layout(
+        record_id='444', headers=headers
+    )
+    assert result == {}
+    assert len(mock_client.method_calls) == 1
+    call = mock_client.method_calls[0]
+    assert call[1][0] == "GET"
+    assert call[1][1] == f"{CASE_URL}/describe/layouts/444"
+    if with_headers:
+        assert "Sforce-Auto-Assign" in call[2]["headers"]
+        assert call[2]["headers"]["Sforce-Auto-Assign"] == "FALSE"
+    else:
+        assert "Sforce-Auto-Assign" not in call[2]["headers"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("with_headers", (True, False))
+async def test_get_with_request_headers(
+    with_headers, mock_httpx_client
+):
+    """
+    Ensure custom headers are used for get requests
+    when passed.
+    """
+    _, mock_client, inner = mock_httpx_client
+    happy_result = httpx.Response(200, content=b'{}')
+    inner(happy_result)
+
+    sf_type = _create_sf_type()
+    headers = None
+    headers = {'Sforce-Auto-Assign': 'FALSE'} if with_headers else None
+
+    result = await sf_type.get(
+        record_id='444', headers=headers
+    )
+    assert result == {}
+    assert len(mock_client.method_calls) == 1
+    call = mock_client.method_calls[0]
+    assert call[1][0] == "GET"
+    assert call[1][1] == f"{CASE_URL}/444"
+    if with_headers:
+        assert "Sforce-Auto-Assign" in call[2]["headers"]
+        assert call[2]["headers"]["Sforce-Auto-Assign"] == "FALSE"
+    else:
+        assert "Sforce-Auto-Assign" not in call[2]["headers"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("with_headers", (True, False))
+async def test_get_customid_with_request_headers(
+    with_headers, mock_httpx_client
+):
+    """
+    Ensure custom headers are used for get_by_custom_id requests
+    when passed.
+    """
+    _, mock_client, inner = mock_httpx_client
+    happy_result = httpx.Response(200, content=b'{}')
+    inner(happy_result)
+
+    sf_type = _create_sf_type()
+    headers = {'Sforce-Auto-Assign': 'FALSE'} if with_headers else None
+
+    result = await sf_type.get_by_custom_id(
+        custom_id_field='some-field',
+        custom_id='444',
+        headers=headers
+    )
+    assert result == {}
+    assert len(mock_client.method_calls) == 1
+    call = mock_client.method_calls[0]
+    assert call[1][0] == "GET"
+    assert call[1][1] == f"{CASE_URL}/some-field/444"
+    if with_headers:
+        assert "Sforce-Auto-Assign" in call[2]["headers"]
+        assert call[2]["headers"]["Sforce-Auto-Assign"] == "FALSE"
+    else:
+        assert "Sforce-Auto-Assign" not in call[2]["headers"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("with_headers", (True, False))
+async def test_create_with_request_headers(
+    with_headers, mock_httpx_client
+):
+    """
+    Ensure custom headers are used for create requests
+    when passed.
+    """
+    _, mock_client, inner = mock_httpx_client
+    happy_result = httpx.Response(200, content=b'{}')
+    inner(happy_result)
+
+    sf_type = _create_sf_type()
+    headers = {'Sforce-Auto-Assign': 'FALSE'} if with_headers else None
+
+    result = await sf_type.create(
+        data={'some': 'data'},
+        headers=headers
+    )
+    assert result == {}
+    assert len(mock_client.method_calls) == 1
+    call = mock_client.method_calls[0]
+    assert call[1][0] == "POST"
+    assert call[1][1] == f"{CASE_URL}/"
+    assert call[2]["data"] == '{"some": "data"}'
+    if with_headers:
+        assert "Sforce-Auto-Assign" in call[2]["headers"]
+        assert call[2]["headers"]["Sforce-Auto-Assign"] == "FALSE"
+    else:
+        assert "Sforce-Auto-Assign" not in call[2]["headers"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("with_headers,with_raw_response", (
+    (True, False),
+    (True, True),
+    (False, False),
+    (False, True),
+))
+async def test_update_with_request_headers(
+    with_headers, with_raw_response, mock_httpx_client
+):
+    """
+    Ensure custom headers are used for update requests
+    when passed. Test raw_response kwarg also.
+    """
+    _, mock_client, inner = mock_httpx_client
+    happy_result = httpx.Response(200, content=b'{}')
+    inner(happy_result)
+
+    sf_type = _create_sf_type()
+    headers = {'Sforce-Auto-Assign': 'FALSE'} if with_headers else None
+
+    result = await sf_type.update(
+        'some-case-id',
+        {'some': 'data'},
+        headers=headers,
+        raw_response=with_raw_response
+    )
+    if with_raw_response:
+        assert result == happy_result
+    else:
+        assert result == 200
+    assert len(mock_client.method_calls) == 1
+    call = mock_client.method_calls[0]
+    assert call[1][0] == "PATCH"
+    assert call[1][1] == f"{CASE_URL}/some-case-id"
+    assert call[2]["data"] == '{"some": "data"}'
+    if with_headers:
+        assert "Sforce-Auto-Assign" in call[2]["headers"]
+        assert call[2]["headers"]["Sforce-Auto-Assign"] == "FALSE"
+    else:
+        assert "Sforce-Auto-Assign" not in call[2]["headers"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("with_headers,with_raw_response", (
+    (True, False),
+    (True, True),
+    (False, False),
+    (False, True),
+))
+async def test_upsert_with_request_headers(
+    with_headers, with_raw_response, mock_httpx_client
+):
+    """
+    Ensure custom headers are used for upsert requests
+    when passed. Test raw_response kwarg also.
+    """
+    _, mock_client, inner = mock_httpx_client
+    happy_result = httpx.Response(200, content=b'{}')
+    inner(happy_result)
+
+    sf_type = _create_sf_type()
+    headers = {'Sforce-Auto-Assign': 'FALSE'} if with_headers else None
+    result = await sf_type.upsert(
+        'some-case-id',
+        {'some': 'data'},
+        headers=headers,
+        raw_response=with_raw_response
+    )
+    if with_raw_response:
+        assert result == happy_result
+    else:
+        assert result == 200
+    assert len(mock_client.method_calls) == 1
+    call = mock_client.method_calls[0]
+    assert call[1][0] == "PATCH"
+    assert call[1][1] == f"{CASE_URL}/some-case-id"
+    assert call[2]["data"] == '{"some": "data"}'
+    if with_headers:
+        assert "Sforce-Auto-Assign" in call[2]["headers"]
+        assert call[2]["headers"]["Sforce-Auto-Assign"] == "FALSE"
+    else:
+        assert "Sforce-Auto-Assign" not in call[2]["headers"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("with_headers,with_raw_response", (
+    (True, False),
+    (True, True),
+    (False, False),
+    (False, True),
+))
+async def test_delete_with_request_headers(
+    with_headers, with_raw_response, mock_httpx_client
+):
+    """
+    Ensure custom headers are used for delete requests
+    when passed. Test raw_response kwarg also.
+    """
+    _, mock_client, inner = mock_httpx_client
+    happy_result = httpx.Response(200, content=b'{}')
+    inner(happy_result)
+
+    sf_type = _create_sf_type()
+    headers = {'Sforce-Auto-Assign': 'FALSE'} if with_headers else None
+    result = await sf_type.delete(
+        'some-case-id',
+        headers=headers,
+        raw_response=with_raw_response
+    )
+    if with_raw_response:
+        assert result == happy_result
+    else:
+        assert result == 200
+    assert len(mock_client.method_calls) == 1
+    call = mock_client.method_calls[0]
+    assert call[1][0] == "DELETE"
+    assert call[1][1] == f"{CASE_URL}/some-case-id"
+    if with_headers:
+        assert "Sforce-Auto-Assign" in call[2]["headers"]
+        assert call[2]["headers"]["Sforce-Auto-Assign"] == "FALSE"
+    else:
+        assert "Sforce-Auto-Assign" not in call[2]["headers"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("with_headers", (True, False))
+async def test_deleted_with_request_headers(
+    with_headers, mock_httpx_client
+):
+    """
+    Ensure custom headers are used for deleted requests
+    when passed.
+    """
+    _, mock_client, inner = mock_httpx_client
+    happy_result = httpx.Response(200, content=b'{}')
+    inner(happy_result)
+
+    sf_type = _create_sf_type()
+    start = datetime.now()
+    end = datetime.now()
+    headers = {'Sforce-Auto-Assign': 'FALSE'} if with_headers else None
+    result = await sf_type.deleted(
+        start, end, headers=headers,
+    )
+    start = date_to_iso8601(start)
+    end = date_to_iso8601(end)
+    assert result == {}
+    assert len(mock_client.method_calls) == 1
+    call = mock_client.method_calls[0]
+    assert call[1][0] == "GET"
+    assert call[1][1] == f"{CASE_URL}/deleted/?start={start}&end={end}"
+    if with_headers:
+        assert "Sforce-Auto-Assign" in call[2]["headers"]
+        assert call[2]["headers"]["Sforce-Auto-Assign"] == "FALSE"
+    else:
+        assert "Sforce-Auto-Assign" not in call[2]["headers"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("with_headers", (True, False))
+async def test_updated_with_request_headers(
+    with_headers, mock_httpx_client
+):
+    """
+    Ensure custom headers are used for updated requests
+    when passed.
+    """
+    _, mock_client, inner = mock_httpx_client
+    happy_result = httpx.Response(200, content=b'{}')
+    inner(happy_result)
+
+    sf_type = _create_sf_type()
+    start = datetime.now()
+    end = datetime.now()
+    headers = {'Sforce-Auto-Assign': 'FALSE'} if with_headers else None
+    result = await sf_type.updated(
+        start, end, headers=headers,
+    )
+    start = date_to_iso8601(start)
+    end = date_to_iso8601(end)
+    assert result == {}
+    assert len(mock_client.method_calls) == 1
+    call = mock_client.method_calls[0]
+    assert call[1][0] == "GET"
+    assert call[1][1] == f"{CASE_URL}/updated/?start={start}&end={end}"
+    if with_headers:
+        assert "Sforce-Auto-Assign" in call[2]["headers"]
+        assert call[2]["headers"]["Sforce-Auto-Assign"] == "FALSE"
+    else:
+        assert "Sforce-Auto-Assign" not in call[2]["headers"]
+
+# # # # # # # # # # # # # # # # # # # # # #
+#
+# AsyncSalesforce Tests
+#
+# # # # # # # # # # # # # # # # # # # # # #
+
+
+@pytest.mark.asyncio
+async def test_build_async_with_session_success(constants, mock_httpx_client):
+    """
+    Test the builder function and pass a custom session
+    """
+    _, mock_client, inner = mock_httpx_client
+    happy_result = httpx.Response(
+        200,
+        content=constants["LOGIN_RESPONSE_SUCCESS"]
+    )
+    inner(happy_result)
+    mock_client.custom_session_attrib = "X-1-2-3"
+
+    client = await build_async_salesforce_client(
+        session=mock_client,
+        username='foo@bar.com',
+        password='password',
+        security_token='token'
+    )
+    assert isinstance(client, AsyncSalesforce)
+    assert constants["SESSION_ID"] == client.session_id
+    assert mock_client == client.session
+    assert client.session.custom_session_attrib == "X-1-2-3"
+    assert len(mock_client.method_calls) == 1
+    call = mock_client.method_calls[0]
+    assert call[0] == "post"
+    assert call[1][0].startswith(
+        "https://login.salesforce.com/services/Soap/u/"
+    )
+    assert "SOAPAction" in call[2]["headers"]
+    assert call[2]["headers"]["SOAPAction"] == "login"
+
+
+def test_client_custom_version():
+    """
+    Check custom version appears in URL
+    """
+    expected_version = '4.2'
+    client = AsyncSalesforce(
+        session=mock.AsyncMock(),
+        version=expected_version
+    )
+    assert client.base_url.split('/')[-2] == 'v%s' % expected_version
+
+
+def test_custom_session_to_sftype(constants):
+    """
+    Check session gets passed to SFType
+    """
+    mock_sesh = mock.AsyncMock()
+    mock_sesh.custom_session_attrib = "X-1-2-3"
+    client = AsyncSalesforce(
+        session=mock_sesh,
+        session_id=constants["SESSION_ID"],
+    )
+    assert client.session == client.Contact.session == mock_sesh
+    assert client.Contact.session.custom_session_attrib == "X-1-2-3"
+
+
+# pylint: disable=protected-access
+def test_proxies_inherited_by_default(constants):
+    """
+    Check session gets passed to SFType and proxies are inherited
+    """
+    client = AsyncSalesforce(
+        session_id=constants["SESSION_ID"],
+        proxies=constants["PROXIES"]
+    )
+    # proxies arg should be ignored in this case.
+    # no_proxies_client = AsyncSalesforce(
+    #     session=httpx.AsyncClient(),
+    #     session_id=constants["SESSION_ID"],
+    #     proxies=constants["PROXIES"]
+    # )
+    # with monkeypatch for httpx in place, this is a mock object
+    # assert client.session._mounts
+    # assert client.session._mounts == client.Contact.session._mounts
+    assert client._proxies == client.Contact._proxies == constants["PROXIES"]
+    # assert not no_proxies_client.session._mounts
+
+
+# pylint: disable=unused-argument
+@pytest.fixture()
+def sf_client(constants, mock_httpx_client):
+    """Simple fixture for crafting the client used below"""
+    client = AsyncSalesforce(
+        session_id=constants["SESSION_ID"],
+        proxies=constants["PROXIES"]
+    )
+    client.headers = {}
+    client.base_url = 'https://localhost/'
+    client.metadata_url = 'https://localhost/metadata/'
+    return client
+
+
+@pytest.mark.asyncio
+async def test_api_usage_simple(mock_httpx_client, sf_client):
+    """
+    Test simple api usage parsing
+    """
+    _, _, inner = mock_httpx_client
+    happy_result = httpx.Response(
+        200,
+        content='{"example": 1}',
+        headers={"Sforce-Limit-Info": "api-usage=18/5000"}
+    )
+    inner(happy_result)
+    await sf_client.query('q')
+    assert sf_client.api_usage == {'api-usage': Usage(18, 5000)}
+
+
+@pytest.mark.asyncio
+async def test_api_usage_per_app(mock_httpx_client, sf_client):
+    """
+    Test per-app api usage parsing
+    """
+    _, _, inner = mock_httpx_client
+    pau = "api-usage=25/5000; per-app-api-usage=17/250(appName=sample-app)"
+    happy_result = httpx.Response(
+        200,
+        content='{"example": 1}',
+        headers={"Sforce-Limit-Info": pau}
+    )
+    inner(happy_result)
+    await sf_client.query('q')
+    expected = {
+        'api-usage': Usage(25, 5000),
+        'per-app-api-usage': PerAppUsage(17, 250, 'sample-app')
+    }
+    assert sf_client.api_usage == expected
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("include_deleted,expected_url", (
+    (True, "https://localhost/queryAll/"),
+    (False, "https://localhost/query/"),
+))
+async def test_query(
+    include_deleted, expected_url, mock_httpx_client, sf_client,
+):
+    """Test querying generates the expected request"""
+    _, mock_client, inner = mock_httpx_client
+    happy_result = httpx.Response(
+        200,
+        content="{}"
+    )
+    inner(happy_result)
+    await sf_client.query(
+        'SELECT ID FROM Account',
+        include_deleted=include_deleted
+    )
+    assert len(mock_client.method_calls) == 1
+    call = mock_client.method_calls[0]
+    assert call[1][0] == "GET"
+    assert call[1][1] == expected_url
+    assert call[2]["headers"] == {}
+    assert call[2]["params"] == {'q': 'SELECT ID FROM Account'}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("include_deleted,expected_url", (
+    (True, "https://localhost/queryAll/next-records-id"),
+    (False, "https://localhost/query/next-records-id"),
+))
+async def test_query_more_id_not_url(
+    include_deleted, expected_url, mock_httpx_client, sf_client,
+):
+    """Test querying generates the expected request"""
+    _, mock_client, inner = mock_httpx_client
+    happy_result = httpx.Response(
+        200,
+        content="{}"
+    )
+    inner(happy_result)
+    await sf_client.query_more(
+        'next-records-id',
+        include_deleted=include_deleted,
+        identifier_is_url=False
+    )
+    assert len(mock_client.method_calls) == 1
+    call = mock_client.method_calls[0]
+    assert call[1][0] == "GET"
+    assert call[1][1] == expected_url
+    assert call[2]["headers"] == {}
+
+
+# pylint: disable=redefined-outer-name
+@pytest.mark.asyncio
+async def test_query_all_iter(
+    mock_httpx_client, sf_client,
+):
+    """Test that we query and fetch additional result sets lazily."""
+    _, mock_client, _ = mock_httpx_client
+    body1 = {
+        "records": [{"ID": "1"}],
+        "done": False,
+        "nextRecordsUrl": "https://example.com/query/next-records-id",
+        "totalSize": 2
+    }
+    body2 = {
+        "records": [{"ID": "2"}],
+        "done": True,
+        "totalSize": 2
+    }
+    responses = [
+        httpx.Response(
+            200,
+            content=json.dumps(body1)
+        ),
+        httpx.Response(
+            200,
+            content=json.dumps(body2)
+        ),
+    ]
+    mock_client.request.side_effect = mock.AsyncMock(side_effect=responses)
+    expected = [OrderedDict([('ID', '1')]), OrderedDict([('ID', '2')])]
+
+    # This should return an Async Generator: collect responses and compare
+    result = sf_client.query_all_iter('SELECT ID FROM Account')
+    collection = []
+    async for item in result:
+        collection.append(item)
+
+    assert collection == expected
+    assert len(mock_client.method_calls) == 2
+
+
+@pytest.mark.asyncio
+async def test_query_all(
+    mock_httpx_client, sf_client,
+):
+    """Test that we query and fetch additional result sets automatically."""
+    _, mock_client, _ = mock_httpx_client
+    body1 = {
+        "records": [{"ID": "1"}],
+        "done": False,
+        "nextRecordsUrl": "https://example.com/query/next-records-id",
+        "totalSize": 2
+    }
+    body2 = {
+        "records": [{"ID": "2"}],
+        "done": True,
+        "totalSize": 2
+    }
+    responses = [
+        httpx.Response(
+            200,
+            content=json.dumps(body1)
+        ),
+        httpx.Response(
+            200,
+            content=json.dumps(body2)
+        ),
+    ]
+    mock_client.request.side_effect = mock.AsyncMock(side_effect=responses)
+    expected = {
+        "totalSize": 2,
+        "records": [OrderedDict([('ID', '1')]), OrderedDict([('ID', '2')])],
+        "done": True
+    }
+
+    # This should eagerly pull all results from all pages
+    result = await sf_client.query_all('SELECT ID FROM Account')
+    assert result == expected
+    assert len(mock_client.method_calls) == 2
+
+
+@pytest.mark.asyncio
+async def test_api_limits(
+    constants, mock_httpx_client, sf_client,
+):
+    """Test method for getting Salesforce organization limits"""
+    _, mock_client, inner = mock_httpx_client
+    happy_result = httpx.Response(
+        200,
+        content=json.dumps(constants["ORGANIZATION_LIMITS_RESPONSE"])
+    )
+    inner(happy_result)
+    result = await sf_client.limits()
+    assert len(mock_client.method_calls) == 1
+    call = mock_client.method_calls[0]
+    assert call[1][0] == "GET"
+    assert call[1][1] == "https://localhost/limits/"
+    assert result == constants["ORGANIZATION_LIMITS_RESPONSE"]
+
+
+@pytest.mark.asyncio
+async def test_md_deploy_success(
+    mock_httpx_client, sf_client,
+):
+    """Test method for metadata deployment"""
+    mock_response = '<?xml version="1.0" ' \
+                    'encoding="UTF-8"?><soapenv:Envelope ' \
+                    'xmlns:soapenv="http://schemas.xmlsoap.org/soap' \
+                    '/envelope/" ' \
+                    'xmlns="http://soap.sforce.com/2006/04/metadata' \
+                    '"><soapenv:Body><deployResponse><result><done' \
+                    '>false</done><id>0Af3B00001CMyfASAT</id><state' \
+                    '>Queued</state></result></deployResponse></soapenv' \
+                    ':Body></soapenv:Envelope>'
+
+    _, mock_client, inner = mock_httpx_client
+    happy_result = httpx.Response(
+        200,
+        content=mock_response
+    )
+    inner(happy_result)
+    async with aiofiles.tempfile.NamedTemporaryFile('wb+') as fl:
+        await fl.write(b'Line1\n Line2')
+        await fl.seek(0)
+        result = await sf_client.deploy(fl.name, sandbox=False)
+    assert result.get("asyncId") == "0Af3B00001CMyfASAT"
+    assert result.get("state") == "Queued"
+
+    assert len(mock_client.method_calls) == 1
+    call = mock_client.method_calls[0]
+    assert call[1][0] == "POST"
+    assert call[1][1] == f"{sf_client.metadata_url}deployRequest"
+
+
+@pytest.mark.asyncio
+async def test_md_deploy_failed_status_code(
+    mock_httpx_client, sf_client,
+):
+    """Test method for metadata deployment on Failure"""
+    _, _, inner = mock_httpx_client
+    bad_result = httpx.Response(
+        2599,
+        request=httpx.Request("POST", f"{sf_client.metadata_url}deployRequest"),
+        content=b"Unrecognized Error"
+    )
+    inner(bad_result)
+    async with aiofiles.tempfile.NamedTemporaryFile('wb+') as fl:
+        await fl.write(b'Line1\n Line2')
+        await fl.seek(0)
+        with pytest.raises(SalesforceGeneralError):
+            await sf_client.deploy(fl.name, sandbox=False)
+
+DEPLOY_PENDING = (
+    '<?xml version="1.0" '
+    'encoding="UTF-8"?><soapenv:Envelope '
+    'xmlns:soapenv="http://schemas.xmlsoap.org/soap'
+    '/envelope/" '
+    'xmlns="http://soap.sforce.com/2006/04/metadata'
+    '"><soapenv:Body><checkDeployStatusResponse><result'
+    '><checkOnly>true</checkOnly><createdBy'
+    '>0053D0000052Xaq</createdBy><createdByName>User '
+    'User</createdByName><createdDate>2020-10-28T15:38:34'
+    '.000Z</createdDate><details><runTestResult'
+    '><numFailures>0</numFailures><numTestsRun>0'
+    '</numTestsRun><totalTime>0.0</totalTime'
+    '></runTestResult></details><done>false</done><id'
+    '>0Af3D00001NViC1SAL</id><ignoreWarnings>false'
+    '</ignoreWarnings><lastModifiedDate>2020-10-28T15:38'
+    ':34.000Z</lastModifiedDate><numberComponentErrors>0'
+    '</numberComponentErrors><numberComponentsDeployed>0'
+    '</numberComponentsDeployed><numberComponentsTotal>0'
+    '</numberComponentsTotal><numberTestErrors>0'
+    '</numberTestErrors><numberTestsCompleted>0'
+    '</numberTestsCompleted><numberTestsTotal>0'
+    '</numberTestsTotal><rollbackOnError>true'
+    '</rollbackOnError><runTestsEnabled>false'
+    '</runTestsEnabled><status>Pending</status><success'
+    '>false</success></result></checkDeployStatusResponse'
+    '></soapenv:Body></soapenv:Envelope>'
+)
+
+DEPLOY_SUCCESS = (
+    '<?xml version="1.0" '
+    'encoding="UTF-8"?><soapenv:Envelope '
+    'xmlns:soapenv="http://schemas.xmlsoap.org/soap'
+    '/envelope/" '
+    'xmlns="http://soap.sforce.com/2006/04/metadata'
+    '"><soapenv:Body><checkDeployStatusResponse><result'
+    '><checkOnly>false</checkOnly><completedDate>2020-10'
+    '-28T13:33:29.000Z</completedDate><createdBy'
+    '>0053D0000052Xaq</createdBy><createdByName>User '
+    'User</createdByName><createdDate>2020-10-28T13:33:25'
+    '.000Z</createdDate><details><componentSuccesses'
+    '><changed>true</changed><componentType>ApexSettings'
+    '</componentType><created>false</created><createdDate'
+    '>2020-10-28T13:33:29.000Z</createdDate><deleted'
+    '>false</deleted><fileName>shape/settings/Apex'
+    '.settings</fileName><fullName>Apex</fullName'
+    '><success>true</success></componentSuccesses'
+    '><componentSuccesses><changed>true</changed'
+    '><componentType>ChatterSettings</componentType'
+    '><created>false</created><createdDate>2020-10-28T13'
+    ':33:29.000Z</createdDate><deleted>false</deleted'
+    '><fileName>shape/settings/Chatter.settings</fileName'
+    '><fullName>Chatter</fullName><success>true</success'
+    '></componentSuccesses><componentSuccesses><changed'
+    '>true</changed><componentType></componentType'
+    '><created>false</created><createdDate>2020-10-28T13'
+    ':33:29.000Z</createdDate><deleted>false</deleted'
+    '><fileName>shape/package.xml</fileName><fullName'
+    '>package.xml</fullName><success>true</success'
+    '></componentSuccesses><componentSuccesses><changed'
+    '>true</changed><componentType>LightningExperienceSettings'
+    '</componentType><created>false</created><createdDate>'
+    '2020-10-28T13:33:29.000Z</createdDate><deleted>false'
+    '</deleted><fileName>shape/settings/LightningExperience.'
+    'settings</fileName><fullName>LightningExperience</fullName>'
+    '<success>true</success></componentSuccesses><component'
+    'Successes><changed>true</changed><componentType>LanguageSettings'
+    '</componentType><created>false</created><createdDate>'
+    '2020-10-28T13:33:29.000Z</createdDate><deleted>false</deleted>'
+    '<fileName>shape/settings/Language.settings</fileName>'
+    '<fullName>Language</fullName><success>true</success>'
+    '</componentSuccesses><runTestResult><numFailures>0</numFailures>'
+    '<numTestsRun>0</numTestsRun><totalTime>0.0</totalTime>'
+    '</runTestResult></details><done>true</done><id>0Af3D00001NVCnwSAH'
+    '</id><ignoreWarnings>false</ignoreWarnings><lastModifiedDate>'
+    '2020-10-28T13:33:29.000Z</lastModifiedDate>'
+    '<numberComponentErrors>0</numberComponentErrors>'
+    '<numberComponentsDeployed>4</numberComponentsDeployed>'
+    '<numberComponentsTotal>4</numberComponentsTotal>'
+    '<numberTestErrors>0</numberTestErrors><numberTestsCompleted>'
+    '0</numberTestsCompleted><numberTestsTotal>0</numberTestsTotal><rollbackOnError>true</rollbackOnError><runTestsEnabled>false</runTestsEnabled><startDate>2020-10-28T13:33:26.000Z</startDate><status>Succeeded</status><success>true</success></result></checkDeployStatusResponse></soapenv:Body></soapenv:Envelope>'
+)
+DEPLOY_PAYLOAD_ERROR = (
+    '<?xml version="1.0" '
+    'encoding="UTF-8"?><soapenv:Envelope '
+    'xmlns:soapenv="http://schemas.xmlsoap.org/soap'
+    '/envelope/" '
+    'xmlns="http://soap.sforce.com/2006/04/metadata'
+    '"><soapenv:Body><checkDeployStatusResponse><result'
+    '><checkOnly>true</checkOnly><completedDate>2020-10'
+    '-28T13:37:48.000Z</completedDate><createdBy'
+    '>0053D0000052Xaq</createdBy><createdByName>User '
+    'User</createdByName><createdDate>2020-10-28T13:37:46'
+    '.000Z</createdDate><details><componentFailures'
+    '><changed>false</changed><componentType'
+    '></componentType><created>false</created'
+    '><createdDate>2020-10-28T13:37:47.000Z</createdDate'
+    '><deleted>false</deleted><fileName>package.xml'
+    '</fileName><fullName>package.xml</fullName><problem'
+    '>No package.xml '
+    'found</problem><problemType>Error</problemType'
+    '><success>false</success></componentFailures'
+    '><runTestResult><numFailures>0</numFailures'
+    '><numTestsRun>0</numTestsRun><totalTime>0.0'
+    '</totalTime></runTestResult></details><done>true'
+    '</done><id>0Af3D00001NVD0TSAX</id><ignoreWarnings'
+    '>false</ignoreWarnings><lastModifiedDate>2020-10'
+    '-28T13:37:48.000Z</lastModifiedDate'
+    '><numberComponentErrors>0</numberComponentErrors'
+    '><numberComponentsDeployed>0</numberComponentsDeployed><numberComponentsTotal>0</numberComponentsTotal><numberTestErrors>0</numberTestErrors><numberTestsCompleted>0</numberTestsCompleted><numberTestsTotal>0</numberTestsTotal><rollbackOnError>true</rollbackOnError><runTestsEnabled>false</runTestsEnabled><startDate>2020-10-28T13:37:47.000Z</startDate><status>Failed</status><success>false</success></result></checkDeployStatusResponse></soapenv:Body></soapenv:Envelope>'
+)
+
+DEPLOY_IN_PROGRESS = (
+    '<?xml version="1.0" '
+    'encoding="UTF-8"?><soapenv:Envelope '
+    'xmlns:soapenv="http://schemas.xmlsoap.org/soap'
+    '/envelope/" '
+    'xmlns="http://soap.sforce.com/2006/04/metadata'
+    '"><soapenv:Body><checkDeployStatusResponse><result'
+    '><checkOnly>false</checkOnly><createdBy'
+    '>0053D0000052Xaq</createdBy><createdByName>User '
+    'User</createdByName><createdDate>2020-10-28T17:24:30'
+    '.000Z</createdDate><details><runTestResult'
+    '><numFailures>0</numFailures><numTestsRun>0'
+    '</numTestsRun><totalTime>0.0</totalTime'
+    '></runTestResult></details><done>false</done><id'
+    '>0Af3D00001NW8mnSAD</id><ignoreWarnings>false'
+    '</ignoreWarnings><lastModifiedDate>2020-10-28T17:37'
+    ':08.000Z</lastModifiedDate><numberComponentErrors>0'
+    '</numberComponentErrors><numberComponentsDeployed>2'
+    '</numberComponentsDeployed><numberComponentsTotal>3'
+    '</numberComponentsTotal><numberTestErrors>0'
+    '</numberTestErrors><numberTestsCompleted>0'
+    '</numberTestsCompleted><numberTestsTotal>0'
+    '</numberTestsTotal><rollbackOnError>true'
+    '</rollbackOnError><runTestsEnabled>false'
+    '</runTestsEnabled><startDate>2020-10-28T17:24:30'
+    '.000Z</startDate><status>InProgress</status><success'
+    '>false</success></result></checkDeployStatusResponse'
+    '></soapenv:Body></soapenv:Envelope>'
+)
+
+
+@pytest.mark.asyncio
+async def test_check_status_pending(
+    mock_httpx_client, sf_client,
+):
+    """Test method for metadata deployment"""
+    _, mock_client, inner = mock_httpx_client
+    happy_result = httpx.Response(
+        200,
+        content=DEPLOY_PENDING
+    )
+    inner(happy_result)
+
+    result = await sf_client.checkDeployStatus("abdcefg", sandbox=False)
+    assert result.get("state") == "Pending"
+    assert result.get("state_detail") is None
+    assert result.get("deployment_detail") == {
+        'total_count': '0',
+        'failed_count': '0',
+        'deployed_count': '0',
+        'errors': []
+    }
+    assert result.get("unit_test_detail") == {
+        'total_count': '0',
+        'failed_count': '0',
+        'completed_count': '0',
+        'errors': []
+    }
+
+    assert len(mock_client.method_calls) == 1
+    call = mock_client.method_calls[0]
+    assert call[1][0] == "POST"
+    assert call[1][1] == f"{sf_client.metadata_url}deployRequest/abdcefg"
+
+
+@pytest.mark.asyncio
+async def test_check_status_success(
+    mock_httpx_client, sf_client,
+):
+    """Test method for metadata deployment"""
+
+
+    _, mock_client, inner = mock_httpx_client
+    happy_result = httpx.Response(
+        200,
+        content=DEPLOY_SUCCESS
+    )
+    inner(happy_result)
+
+    result = await sf_client.checkDeployStatus("abdcefg", sandbox=False)
+    assert result.get("state") == "Succeeded"
+    assert result.get("state_detail") is None
+    assert result.get("deployment_detail") == {
+        'total_count': '4',
+        'failed_count': '0',
+        'deployed_count': '4',
+        'errors': []
+    }
+    assert result.get("unit_test_detail") == {
+        'total_count': '0',
+        'failed_count': '0',
+        'completed_count': '0',
+        'errors': []
+    }
+
+    assert len(mock_client.method_calls) == 1
+    call = mock_client.method_calls[0]
+    assert call[1][0] == "POST"
+    assert call[1][1] == f"{sf_client.metadata_url}deployRequest/abdcefg"
+
+
+@pytest.mark.asyncio
+async def test_check_status_payload_error(
+    mock_httpx_client, sf_client,
+):
+    """Test method for metadata deployment"""
+    _, mock_client, inner = mock_httpx_client
+    happy_result = httpx.Response(
+        200,
+        content=DEPLOY_PAYLOAD_ERROR
+    )
+    inner(happy_result)
+
+    result = await sf_client.checkDeployStatus("abdcefg", sandbox=False)
+    assert result.get("state") == "Failed"
+    assert result.get("state_detail") is None
+    assert result.get("deployment_detail") == {
+        'total_count': '0',
+        'failed_count': '0',
+        'deployed_count': '0',
+        'errors': [
+            {
+                'type': None, 'file': 'package.xml',
+                'status': 'Error', 'message': 'No package.xml found'
+            }
+        ]
+    }
+    assert result.get("unit_test_detail") == {
+        'total_count': '0',
+        'failed_count': '0',
+        'completed_count': '0',
+        'errors': []
+    }
+    assert len(mock_client.method_calls) == 1
+    call = mock_client.method_calls[0]
+    assert call[1][0] == "POST"
+    assert call[1][1] == f"{sf_client.metadata_url}deployRequest/abdcefg"
+
+
+@pytest.mark.asyncio
+async def test_check_status_in_progress(
+    mock_httpx_client, sf_client,
+):
+    """Test method for metadata deployment"""
+    _, mock_client, inner = mock_httpx_client
+    happy_result = httpx.Response(
+        200,
+        content=DEPLOY_IN_PROGRESS
+    )
+    inner(happy_result)
+
+    result = await sf_client.checkDeployStatus("abdcefg", sandbox=False)
+    assert result.get("state") == "InProgress"
+    assert result.get("state_detail") is None
+    assert result.get("deployment_detail") == {
+        'total_count': '3',
+        'failed_count': '0',
+        'deployed_count': '2',
+        'errors': []
+    }
+    assert result.get("unit_test_detail") == {
+        'total_count': '0',
+        'failed_count': '0',
+        'completed_count': '0',
+        'errors': []
+    }
+
+    assert len(mock_client.method_calls) == 1
+    call = mock_client.method_calls[0]
+    assert call[1][0] == "POST"
+    assert call[1][1] == f"{sf_client.metadata_url}deployRequest/abdcefg"

--- a/simple_salesforce/tests/test_aio/test_api.py
+++ b/simple_salesforce/tests/test_aio/test_api.py
@@ -12,7 +12,7 @@ import pytest
 
 from simple_salesforce.api import PerAppUsage, Usage
 from simple_salesforce.aio.api import (
-    build_async_salesforce_client, AsyncSalesforce, SFType
+    build_async_salesforce_client, AsyncSalesforce, AsyncSFType
 )
 from simple_salesforce.exceptions import SalesforceGeneralError
 from simple_salesforce.util import date_to_iso8601
@@ -23,7 +23,7 @@ CASE_URL = DEFAULT_URL.format("Case")
 
 # # # # # # # # # # # # # # # # # # # # # #
 #
-# SFType Tests
+# AsyncSFType Tests
 #
 # # # # # # # # # # # # # # # # # # # # # #
 
@@ -33,8 +33,8 @@ def _create_sf_type(
         session_id='5',
         sf_instance='my.salesforce.com'
         ):
-    """Creates SFType instances"""
-    return SFType(
+    """Creates AsyncSFType instances"""
+    return AsyncSFType(
         object_name=object_name,
         session_id=session_id,
         sf_instance=sf_instance,
@@ -475,7 +475,7 @@ def test_client_custom_version():
 
 def test_custom_session_to_sftype(constants):
     """
-    Check session gets passed to SFType
+    Check session gets passed to AsyncSFType
     """
     mock_sesh = mock.AsyncMock()
     mock_sesh.custom_session_attrib = "X-1-2-3"
@@ -490,7 +490,7 @@ def test_custom_session_to_sftype(constants):
 # pylint: disable=protected-access
 def test_proxies_inherited_by_default(constants):
     """
-    Check session gets passed to SFType and proxies are inherited
+    Check session gets passed to AsyncSFType and proxies are inherited
     """
     client = AsyncSalesforce(
         session_id=constants["SESSION_ID"],
@@ -507,20 +507,6 @@ def test_proxies_inherited_by_default(constants):
     # assert client.session._mounts == client.Contact.session._mounts
     assert client._proxies == client.Contact._proxies == constants["PROXIES"]
     # assert not no_proxies_client.session._mounts
-
-
-# pylint: disable=unused-argument
-@pytest.fixture()
-def sf_client(constants, mock_httpx_client):
-    """Simple fixture for crafting the client used below"""
-    client = AsyncSalesforce(
-        session_id=constants["SESSION_ID"],
-        proxies=constants["PROXIES"]
-    )
-    client.headers = {}
-    client.base_url = 'https://localhost/'
-    client.metadata_url = 'https://localhost/metadata/'
-    return client
 
 
 @pytest.mark.asyncio

--- a/simple_salesforce/tests/test_aio/test_bulk.py
+++ b/simple_salesforce/tests/test_aio/test_bulk.py
@@ -1,0 +1,565 @@
+"""Test for bulk.py"""
+import http.client as http
+import re
+import unittest
+from unittest.mock import patch
+
+import requests
+import responses
+from simple_salesforce import tests
+from simple_salesforce.api import Salesforce
+
+
+# class TestSFBulkHandler(unittest.TestCase):
+#     """Test for SFBulkHandler"""
+
+#     def test_bulk_handler(self):
+#         """Test bulk handler creation"""
+#         session = requests.Session()
+#         client = Salesforce(session_id=tests.SESSION_ID,
+#                             instance_url=tests.SERVER_URL,
+#                             session=session)
+#         bulk_handler = client.bulk
+
+#         self.assertIs(tests.SESSION_ID, bulk_handler.session_id)
+#         self.assertIs(client.bulk_url, bulk_handler.bulk_url)
+#         self.assertEqual(tests.BULK_HEADERS, bulk_handler.headers)
+
+
+# class TestSFBulkType(unittest.TestCase):
+#     """Test SFBulkType"""
+
+#     def setUp(self):
+#         request_patcher = patch('simple_salesforce.api.requests')
+#         self.mockrequest = request_patcher.start()
+#         self.addCleanup(request_patcher.stop)
+#         self.expected = [
+#             {
+#                 "success": True,
+#                 "created": True,
+#                 "id": "001xx000003DHP0AAO",
+#                 "errors": []
+#             },
+#             {
+#                 "success": True,
+#                 "created": True,
+#                 "id": "001xx000003DHP1AAO",
+#                 "errors": []
+#             }
+#         ]
+#         self.expected_query = [
+#             {"Id": "001xx000003DHP0AAO", "AccountId": "ID-13",
+#              "Email": "contact1@example.com",
+#              "FirstName": "Bob", "LastName": "x"},
+#             {"Id": "001xx000003DHP1AAO", "AccountId": "ID-24",
+#              "Email": "contact2@example.com",
+#              "FirstName": "Alice", "LastName": "y"},
+#             {"Id": "001xx000003DHP0AAO", "AccountId": "ID-13",
+#              "Email": "contact1@example.com",
+#              "FirstName": "Bob", "LastName": "x"},
+#             {"Id": "001xx000003DHP1AAO", "AccountId": "ID-24",
+#              "Email": "contact2@example.com",
+#              "FirstName": "Alice", "LastName": "y"}
+#         ]
+
+#     def test_bulk_type(self):
+#         """Test bulk type creation"""
+#         session = requests.Session()
+#         client = Salesforce(session_id=tests.SESSION_ID,
+#                             instance_url=tests.SERVER_URL,
+#                             session=session)
+#         contact = client.bulk.Contact
+#         self.assertIs('Contact', contact.object_name)
+#         self.assertIs(client.bulk_url, contact.bulk_url)
+#         self.assertEqual(tests.BULK_HEADERS, contact.headers)
+
+#     @responses.activate
+#     def test_delete(self):
+#         """Test bulk delete records"""
+#         operation = 'delete'
+#         responses.add(
+#             responses.POST,
+#             re.compile(r'^https://[^/job].*/job$'),
+#             body='{"apiVersion": 42.0, "concurrencyMode": "Parallel",'
+#             '"contentType": "JSON","id": "Job-1","object": "Contact",'
+#             '"operation": "%s","state": "Open"}' % operation,
+#             status=http.OK)
+#         responses.add(
+#             responses.POST,
+#             re.compile(r'^https://[^/job].*/job/Job-1/batch$'),
+#             body='{"id": "Batch-1","jobId": "Job-1","state": "Queued"}',
+#             status=http.OK
+#         )
+#         responses.add(
+#             responses.POST,
+#             re.compile(r'^https://[^/job].*/job/Job-1$'),
+#             body='{"apiVersion" : 42.0, "concurrencyMode" : "Parallel",'
+#             '"contentType" : "JSON","id" : "Job-1","object" : "Contact",'
+#             '"operation" : "%s","state" : "Closed"}' % operation,
+#             status=http.OK
+#         )
+#         responses.add(
+#             responses.GET,
+#             re.compile(r'^https://[^/job].*/job/Job-1/batch/Batch-1$'),
+#             body='{"id": "Batch-1","jobId": "Job-1","state": "InProgress"}',
+#             status=http.OK
+#         )
+#         responses.add(
+#             responses.GET,
+#             re.compile(r'^https://[^/job].*/job/Job-1/batch/Batch-1$'),
+#             body='{"id": "Batch-1","jobId": "Job-1","state": "Completed"}',
+#             status=http.OK
+#         )
+#         responses.add(
+#             responses.GET,
+#             re.compile(
+#                 r'^https://[^/job].*/job/Job-1/batch/Batch-1/result$'),
+#             body='[{"success": true,"created": true,"id": "001xx000003DHP0AAO",'
+#             '"errors": []},{"success": true,"created": true,'
+#             '"id": "001xx000003DHP1AAO","errors": []}]',
+#             status=http.OK
+#         )
+#         data = [{
+#             'id': 'ID-1',
+#         }, {
+#             'id': 'ID-2',
+#         }]
+#         session = requests.Session()
+#         client = Salesforce(session_id=tests.SESSION_ID,
+#                             instance_url=tests.SERVER_URL,
+#                             session=session)
+#         contact = client.bulk.Contact.delete(data)
+#         self.assertEqual(self.expected, contact)
+
+#     @responses.activate
+#     def test_insert(self):
+#         """Test bulk insert records"""
+#         operation = 'insert'
+#         responses.add(
+#             responses.POST,
+#             re.compile(r'^https://[^/job].*/job$'),
+#             body='{"apiVersion": 42.0, "concurrencyMode": "Parallel",'
+#             '"contentType": "JSON","id": "Job-1","object": "Contact",'
+#             '"operation": "%s","state": "Open"}' % operation,
+#             status=http.OK)
+#         responses.add(
+#             responses.POST,
+#             re.compile(r'^https://[^/job].*/job/Job-1/batch$'),
+#             body='{"id": "Batch-1","jobId": "Job-1","state": "Queued"}',
+#             status=http.OK
+#         )
+#         responses.add(
+#             responses.POST,
+#             re.compile(r'^https://[^/job].*/job/Job-1$'),
+#             body='{"apiVersion" : 42.0, "concurrencyMode" : "Parallel",'
+#             '"contentType" : "JSON","id" : "Job-1","object" : "Contact",'
+#             '"operation" : "%s","state" : "Closed"}' % operation,
+#             status=http.OK
+#         )
+#         responses.add(
+#             responses.GET,
+#             re.compile(r'^https://[^/job].*/job/Job-1/batch/Batch-1$'),
+#             body='{"id": "Batch-1","jobId": "Job-1","state": "InProgress"}',
+#             status=http.OK
+#         )
+#         responses.add(
+#             responses.GET,
+#             re.compile(r'^https://[^/job].*/job/Job-1/batch/Batch-1$'),
+#             body='{"id": "Batch-1","jobId": "Job-1","state": "Completed"}',
+#             status=http.OK
+#         )
+#         responses.add(
+#             responses.GET,
+#             re.compile(
+#                 r'^https://[^/job].*/job/Job-1/batch/Batch-1/result$'),
+#             body='[{"success": true,"created": true,"id": "001xx000003DHP0AAO",'
+#             '"errors": []},{"success": true,"created": true,'
+#             '"id": "001xx000003DHP1AAO","errors": []}]',
+#             status=http.OK
+#         )
+
+#         data = [{
+#             'AccountId': 'ID-1',
+#             'Email': 'contact1@example.com',
+#             'FirstName': 'Bob',
+#             'LastName': 'x'
+#         }, {
+#             'AccountId': 'ID-2',
+#             'Email': 'contact2@example.com',
+#             'FirstName': 'Alice',
+#             'LastName': 'y'
+#         }]
+#         session = requests.Session()
+#         client = Salesforce(session_id=tests.SESSION_ID,
+#                             instance_url=tests.SERVER_URL,
+#                             session=session)
+#         contact = client.bulk.Contact.insert(data)
+#         self.assertEqual(self.expected, contact)
+
+#     @responses.activate
+#     def test_upsert(self):
+#         """Test bulk upsert records"""
+#         operation = 'upsert'
+#         responses.add(
+#             responses.POST,
+#             re.compile(r'^https://[^/job].*/job$'),
+#             body='{"apiVersion": 42.0, "concurrencyMode": "Parallel",'
+#             '"contentType": "JSON","id": "Job-1","object": "Contact",'
+#             '"operation": "%s","state": "Open"}' % operation,
+#             status=http.OK)
+#         responses.add(
+#             responses.POST,
+#             re.compile(r'^https://[^/job].*/job/Job-1/batch$'),
+#             body='{"id": "Batch-1","jobId": "Job-1","state": "Queued"}',
+#             status=http.OK
+#         )
+#         responses.add(
+#             responses.POST,
+#             re.compile(r'^https://[^/job].*/job/Job-1$'),
+#             body='{"apiVersion" : 42.0, "concurrencyMode" : "Parallel",'
+#             '"contentType" : "JSON","id" : "Job-1","object" : "Contact",'
+#             '"operation" : "%s","state" : "Closed"}' % operation,
+#             status=http.OK
+#         )
+#         responses.add(
+#             responses.GET,
+#             re.compile(r'^https://[^/job].*/job/Job-1/batch/Batch-1$'),
+#             body='{"id": "Batch-1","jobId": "Job-1","state": "InProgress"}',
+#             status=http.OK
+#         )
+#         responses.add(
+#             responses.GET,
+#             re.compile(r'^https://[^/job].*/job/Job-1/batch/Batch-1$'),
+#             body='{"id": "Batch-1","jobId": "Job-1","state": "Completed"}',
+#             status=http.OK
+#         )
+#         responses.add(
+#             responses.GET,
+#             re.compile(
+#                 r'^https://[^/job].*/job/Job-1/batch/Batch-1/result$'),
+#             body='[{"success": true,"created": true,"id": "001xx000003DHP0AAO",'
+#             '"errors": []},{"success": true,"created": true,'
+#             '"id": "001xx000003DHP1AAO","errors": []}]',
+#             status=http.OK
+#         )
+
+#         data = [{
+#             'Custom_Id__c': 'CustomID1',
+#             'AccountId': 'ID-13',
+#             'Email': 'contact1@example.com',
+#             'FirstName': 'Bob',
+#             'LastName': 'x'
+#         }, {
+#             'Custom_Id__c': 'CustomID2',
+#             'AccountId': 'ID-24',
+#             'Email': 'contact2@example.com',
+#             'FirstName': 'Alice',
+#             'LastName': 'y'
+#         }]
+#         session = requests.Session()
+#         client = Salesforce(session_id=tests.SESSION_ID,
+#                             instance_url=tests.SERVER_URL,
+#                             session=session)
+#         contact = client.bulk.Contact.upsert(data, 'Custom_Id__c')
+#         self.assertEqual(self.expected, contact)
+
+#     @responses.activate
+#     def test_update(self):
+#         """Test bulk update records"""
+#         operation = 'upsert'
+#         responses.add(
+#             responses.POST,
+#             re.compile(r'^https://[^/job].*/job$'),
+#             body='{"apiVersion": 42.0, "concurrencyMode": "Parallel",'
+#             '"contentType": "JSON","id": "Job-1","object": "Contact",'
+#             '"operation": "%s","state": "Open"}' % operation,
+#             status=http.OK)
+#         responses.add(
+#             responses.POST,
+#             re.compile(r'^https://[^/job].*/job/Job-1/batch$'),
+#             body='{"id": "Batch-1","jobId": "Job-1","state": "Queued"}',
+#             status=http.OK
+#         )
+#         responses.add(
+#             responses.POST,
+#             re.compile(r'^https://[^/job].*/job/Job-1$'),
+#             body='{"apiVersion" : 42.0, "concurrencyMode" : "Parallel",'
+#             '"contentType" : "JSON","id" : "Job-1","object" : "Contact",'
+#             '"operation" : "%s","state" : "Closed"}' % operation,
+#             status=http.OK
+#         )
+#         responses.add(
+#             responses.GET,
+#             re.compile(r'^https://[^/job].*/job/Job-1/batch/Batch-1$'),
+#             body='{"id": "Batch-1","jobId": "Job-1","state": "InProgress"}',
+#             status=http.OK
+#         )
+#         responses.add(
+#             responses.GET,
+#             re.compile(r'^https://[^/job].*/job/Job-1/batch/Batch-1$'),
+#             body='{"id": "Batch-1","jobId": "Job-1","state": "Completed"}',
+#             status=http.OK
+#         )
+#         responses.add(
+#             responses.GET,
+#             re.compile(
+#                 r'^https://[^/job].*/job/Job-1/batch/Batch-1/result$'),
+#             body='[{"success": true,"created": true,"id": "001xx000003DHP0AAO",'
+#             '"errors": []},{"success": true,"created": true,'
+#             '"id": "001xx000003DHP1AAO","errors": []}]',
+#             status=http.OK
+#         )
+
+#         data = [{
+#             'Id': '001xx000003DHP0AAO',
+#             'AccountId': 'ID-13',
+#             'Email': 'contact1@example.com',
+#             'FirstName': 'Bob',
+#             'LastName': 'x'
+#         }, {
+#             'Id': '001xx000003DHP1AAO',
+#             'AccountId': 'ID-24',
+#             'Email': 'contact2@example.com',
+#             'FirstName': 'Alice',
+#             'LastName': 'y'
+#         }]
+#         session = requests.Session()
+#         client = Salesforce(session_id=tests.SESSION_ID,
+#                             instance_url=tests.SERVER_URL,
+#                             session=session)
+#         contact = client.bulk.Contact.update(data)
+#         self.assertEqual(self.expected, contact)
+
+#     @responses.activate
+#     def test_query(self):
+#         """Test bulk query records"""
+#         operation = 'query'
+#         responses.add(
+#             responses.POST,
+#             re.compile(r'^https://[^/job].*/job$'),
+#             body='{"apiVersion": 42.0, "concurrencyMode": "Parallel",'
+#             '"contentType": "JSON","id": "Job-1","object": "Contact",'
+#             '"operation": "%s","state": "Open"}' % operation,
+#             status=http.OK)
+#         responses.add(
+#             responses.POST,
+#             re.compile(r'^https://[^/job].*/job/Job-1/batch$'),
+#             body='{"id": "Batch-1","jobId": "Job-1","state": "Queued"}',
+#             status=http.OK
+#         )
+#         responses.add(
+#             responses.POST,
+#             re.compile(r'^https://[^/job].*/job/Job-1$'),
+#             body='{"apiVersion" : 42.0, "concurrencyMode" : "Parallel",'
+#             '"contentType" : "JSON","id" : "Job-1","object" : "Contact",'
+#             '"operation" : "%s","state" : "Closed"}' % operation,
+#             status=http.OK
+#         )
+#         responses.add(
+#             responses.GET,
+#             re.compile(r'^https://[^/job].*/job/Job-1/batch/Batch-1$'),
+#             body='{"id": "Batch-1","jobId": "Job-1","state": "InProgress"}',
+#             status=http.OK
+#         )
+#         responses.add(
+#             responses.GET,
+#             re.compile(r'^https://[^/job].*/job/Job-1/batch/Batch-1$'),
+#             body='{"id": "Batch-1","jobId": "Job-1","state": "Completed"}',
+#             status=http.OK
+#         )
+#         responses.add(
+#             responses.GET,
+#             re.compile(
+#                 r'^https://[^/job].*/job/Job-1/batch/Batch-1/result$'),
+#             body='["752x000000000F1","752x000000000F2"]',
+#             status=http.OK
+#         )
+
+#         responses.add(
+#             responses.GET,
+#             re.compile(r"""^https://[^/job].*/job/Job-1/batch/Batch-1/result
+#             /752x000000000F1$""", re.X),
+#             body='[{"Id": "001xx000003DHP0AAO", "AccountId": "ID-13",'
+#             '"Email": "contact1@example.com","FirstName": "Bob",'
+#             '"LastName": "x"},{"Id": "001xx000003DHP1AAO",'
+#             '"AccountId": "ID-24","Email": "contact2@example.com",'
+#             '"FirstName": "Alice","LastName": "y"}]',
+#             status=http.OK
+#         )
+#         responses.add(
+#             responses.GET,
+#             re.compile(
+#                 r"""^https://[^/job].*/job/Job-1/batch/Batch-1/result
+#                 /752x000000000F2$""", re.X),
+#             body='[{"Id": "001xx000003DHP0AAO", "AccountId": "ID-13",'
+#             '"Email": "contact1@example.com","FirstName": "Bob",'
+#             '"LastName": "x"},{"Id": "001xx000003DHP1AAO",'
+#             '"AccountId": "ID-24","Email": "contact2@example.com",'
+#             '"FirstName": "Alice","LastName": "y"}]',
+#             status=http.OK
+#         )
+
+#         data = 'SELECT Id,AccountId,Email,FirstName,LastName FROM Contact'
+#         session = requests.Session()
+#         client = Salesforce(session_id=tests.SESSION_ID,
+#                             instance_url=tests.SERVER_URL,
+#                             session=session)
+#         contact = client.bulk.Contact.query(data)
+#         self.assertEqual(self.expected_query, contact)
+
+#     @responses.activate
+#     def test_query_lazy(self):
+#         """Test bulk query records"""
+#         operation = 'query'
+#         responses.add(
+#             responses.POST,
+#             re.compile(r'^https://[^/job].*/job$'),
+#             body='{"apiVersion": 42.0, "concurrencyMode": "Parallel",'
+#             '"contentType": "JSON","id": "Job-1","object": "Contact",'
+#             '"operation": "%s","state": "Open"}' % operation,
+#             status=http.OK)
+#         responses.add(
+#             responses.POST,
+#             re.compile(r'^https://[^/job].*/job/Job-1/batch$'),
+#             body='{"id": "Batch-1","jobId": "Job-1","state": "Queued"}',
+#             status=http.OK
+#         )
+#         responses.add(
+#             responses.POST,
+#             re.compile(r'^https://[^/job].*/job/Job-1$'),
+#             body='{"apiVersion" : 42.0, "concurrencyMode" : "Parallel",'
+#             '"contentType" : "JSON","id" : "Job-1","object" : "Contact",'
+#             '"operation" : "%s","state" : "Closed"}' % operation,
+#             status=http.OK
+#         )
+#         responses.add(
+#             responses.GET,
+#             re.compile(r'^https://[^/job].*/job/Job-1/batch/Batch-1$'),
+#             body='{"id": "Batch-1","jobId": "Job-1","state": "InProgress"}',
+#             status=http.OK
+#         )
+#         responses.add(
+#             responses.GET,
+#             re.compile(r'^https://[^/job].*/job/Job-1/batch/Batch-1$'),
+#             body='{"id": "Batch-1","jobId": "Job-1","state": "Completed"}',
+#             status=http.OK
+#         )
+#         responses.add(
+#             responses.GET,
+#             re.compile(
+#                 r'^https://[^/job].*/job/Job-1/batch/Batch-1/result$'),
+#             body='["752x000000000F1","752x000000000F2"]',
+#             status=http.OK
+#         )
+
+#         responses.add(
+#             responses.GET,
+#             re.compile(r"""^https://[^/job].*/job/Job-1/batch/Batch-1/result
+#             /752x000000000F1$""", re.X),
+#             body='[{"Id": "001xx000003DHP0AAO", "AccountId": "ID-13",'
+#             '"Email": "contact1@example.com","FirstName": "Bob",'
+#             '"LastName": "x"},{"Id": "001xx000003DHP1AAO",'
+#             '"AccountId": "ID-24","Email": "contact2@example.com",'
+#             '"FirstName": "Alice","LastName": "y"}]',
+#             status=http.OK
+#         )
+#         responses.add(
+#             responses.GET,
+#             re.compile(
+#                 r"""^https://[^/job].*/job/Job-1/batch/Batch-1/result
+#                 /752x000000000F2$""", re.X),
+#             body='[{"Id": "001xx000003DHP0AAO", "AccountId": "ID-13",'
+#             '"Email": "contact1@example.com","FirstName": "Bob",'
+#             '"LastName": "x"},{"Id": "001xx000003DHP1AAO",'
+#             '"AccountId": "ID-24","Email": "contact2@example.com",'
+#             '"FirstName": "Alice","LastName": "y"}]',
+#             status=http.OK
+#         )
+
+#         data = 'SELECT Id,AccountId,Email,FirstName,LastName FROM Contact'
+#         session = requests.Session()
+#         client = Salesforce(session_id=tests.SESSION_ID,
+#                             instance_url=tests.SERVER_URL,
+#                             session=session)
+
+#         contact = []
+#         for list_results in client.bulk.Contact.query(data, True):
+#             contact.extend(list_results)
+
+#         self.assertEqual(self.expected_query, contact)
+
+#     @responses.activate
+#     def test_query_all(self):
+#         """Test bulk queryAll records"""
+#         operation = 'queryAll'
+#         responses.add(
+#             responses.POST,
+#             re.compile(r'^https://[^/job].*/job$'),
+#             body='{"apiVersion": 42.0, "concurrencyMode": "Parallel",'
+#             '"contentType": "JSON","id": "Job-1","object": "Contact",'
+#             '"operation": "%s","state": "Open"}' % operation,
+#             status=http.OK)
+#         responses.add(
+#             responses.POST,
+#             re.compile(r'^https://[^/job].*/job/Job-1/batch$'),
+#             body='{"id": "Batch-1","jobId": "Job-1","state": "Queued"}',
+#             status=http.OK
+#         )
+#         responses.add(
+#             responses.POST,
+#             re.compile(r'^https://[^/job].*/job/Job-1$'),
+#             body='{"apiVersion" : 42.0, "concurrencyMode" : "Parallel",'
+#             '"contentType" : "JSON","id" : "Job-1","object" : "Contact",'
+#             '"operation" : "%s","state" : "Closed"}' % operation,
+#             status=http.OK
+#         )
+#         responses.add(
+#             responses.GET,
+#             re.compile(r'^https://[^/job].*/job/Job-1/batch/Batch-1$'),
+#             body='{"id": "Batch-1","jobId": "Job-1","state": "InProgress"}',
+#             status=http.OK
+#         )
+#         responses.add(
+#             responses.GET,
+#             re.compile(r'^https://[^/job].*/job/Job-1/batch/Batch-1$'),
+#             body='{"id": "Batch-1","jobId": "Job-1","state": "Completed"}',
+#             status=http.OK
+#         )
+#         responses.add(
+#             responses.GET,
+#             re.compile(
+#                 r'^https://[^/job].*/job/Job-1/batch/Batch-1/result$'),
+#             body='["752x000000000F1","752x000000000F2"]',
+#             status=http.OK
+#         )
+#         responses.add(
+#             responses.GET,
+#             re.compile(r"""^https://[^/job].*/job/Job-1/batch/Batch-1/result
+#             /752x000000000F1$""", re.X),
+#             body='[{"Id": "001xx000003DHP0AAO", "AccountId": "ID-13",'
+#             '"Email": "contact1@example.com","FirstName": "Bob",'
+#             '"LastName": "x"},{"Id": "001xx000003DHP1AAO",'
+#             '"AccountId": "ID-24","Email": "contact2@example.com",'
+#             '"FirstName": "Alice","LastName": "y"}]',
+#             status=http.OK
+#         )
+#         responses.add(
+#             responses.GET,
+#             re.compile(
+#                 r"""^https://[^/job].*/job/Job-1/batch/Batch-1/result
+#                 /752x000000000F2$""", re.X),
+#             body='[{"Id": "001xx000003DHP0AAO", "AccountId": "ID-13",'
+#             '"Email": "contact1@example.com","FirstName": "Bob",'
+#             '"LastName": "x"},{"Id": "001xx000003DHP1AAO",'
+#             '"AccountId": "ID-24","Email": "contact2@example.com",'
+#             '"FirstName": "Alice","LastName": "y"}]',
+#             status=http.OK
+#         )
+
+#         data = 'SELECT Id,AccountId,Email,FirstName,LastName FROM Contact'
+#         session = requests.Session()
+#         client = Salesforce(session_id=tests.SESSION_ID,
+#                             instance_url=tests.SERVER_URL,
+#                             session=session)
+#         contact = client.bulk.Contact.query_all(data)
+#         self.assertEqual(self.expected_query, contact)

--- a/simple_salesforce/tests/test_aio/test_bulk.py
+++ b/simple_salesforce/tests/test_aio/test_bulk.py
@@ -1,565 +1,99 @@
 """Test for bulk.py"""
-import http.client as http
-import re
-import unittest
-from unittest.mock import patch
+import copy
+import json
+from unittest import mock
 
-import requests
-import responses
-from simple_salesforce import tests
-from simple_salesforce.api import Salesforce
+import httpx
+import pytest
 
 
-# class TestSFBulkHandler(unittest.TestCase):
-#     """Test for SFBulkHandler"""
-
-#     def test_bulk_handler(self):
-#         """Test bulk handler creation"""
-#         session = requests.Session()
-#         client = Salesforce(session_id=tests.SESSION_ID,
-#                             instance_url=tests.SERVER_URL,
-#                             session=session)
-#         bulk_handler = client.bulk
-
-#         self.assertIs(tests.SESSION_ID, bulk_handler.session_id)
-#         self.assertIs(client.bulk_url, bulk_handler.bulk_url)
-#         self.assertEqual(tests.BULK_HEADERS, bulk_handler.headers)
+def test_bulk_handler(sf_client, constants):
+    """Test that BulkHandler Loads Properly"""
+    bulk_handler = sf_client.bulk
+    assert bulk_handler.session_id == sf_client.session_id
+    assert bulk_handler.bulk_url == sf_client.bulk_url
+    assert constants["BULK_HEADERS"] == bulk_handler.headers
 
 
-# class TestSFBulkType(unittest.TestCase):
-#     """Test SFBulkType"""
+def test_bulk_type(sf_client, constants):
+    """Test bulk type creation"""
+    contact = sf_client.bulk.Contact
+    assert contact.bulk_url == sf_client.bulk_url
+    assert constants["BULK_HEADERS"] == contact.headers
+    assert 'Contact' == contact.object_name
 
-#     def setUp(self):
-#         request_patcher = patch('simple_salesforce.api.requests')
-#         self.mockrequest = request_patcher.start()
-#         self.addCleanup(request_patcher.stop)
-#         self.expected = [
-#             {
-#                 "success": True,
-#                 "created": True,
-#                 "id": "001xx000003DHP0AAO",
-#                 "errors": []
-#             },
-#             {
-#                 "success": True,
-#                 "created": True,
-#                 "id": "001xx000003DHP1AAO",
-#                 "errors": []
-#             }
-#         ]
-#         self.expected_query = [
-#             {"Id": "001xx000003DHP0AAO", "AccountId": "ID-13",
-#              "Email": "contact1@example.com",
-#              "FirstName": "Bob", "LastName": "x"},
-#             {"Id": "001xx000003DHP1AAO", "AccountId": "ID-24",
-#              "Email": "contact2@example.com",
-#              "FirstName": "Alice", "LastName": "y"},
-#             {"Id": "001xx000003DHP0AAO", "AccountId": "ID-13",
-#              "Email": "contact1@example.com",
-#              "FirstName": "Bob", "LastName": "x"},
-#             {"Id": "001xx000003DHP1AAO", "AccountId": "ID-24",
-#              "Email": "contact2@example.com",
-#              "FirstName": "Alice", "LastName": "y"}
-#         ]
 
-#     def test_bulk_type(self):
-#         """Test bulk type creation"""
-#         session = requests.Session()
-#         client = Salesforce(session_id=tests.SESSION_ID,
-#                             instance_url=tests.SERVER_URL,
-#                             session=session)
-#         contact = client.bulk.Contact
-#         self.assertIs('Contact', contact.object_name)
-#         self.assertIs(client.bulk_url, contact.bulk_url)
-#         self.assertEqual(tests.BULK_HEADERS, contact.headers)
+EXPECTED_RESULT = [
+    {
+        "success": True,
+        "created": True,
+        "id": "001xx000003DHP0AAO",
+        "errors": []
+    },
+    {
+        "success": True,
+        "created": True,
+        "id": "001xx000003DHP1AAO",
+        "errors": []
+    }
+]
+EXPECTED_QUERY = [
+    {"Id": "001xx000003DHP0AAO", "AccountId": "ID-13",
+        "Email": "contact1@example.com",
+        "FirstName": "Bob", "LastName": "x"},
+    {"Id": "001xx000003DHP1AAO", "AccountId": "ID-24",
+        "Email": "contact2@example.com",
+        "FirstName": "Alice", "LastName": "y"},
+    {"Id": "001xx000003DHP0AAO", "AccountId": "ID-13",
+        "Email": "contact1@example.com",
+        "FirstName": "Bob", "LastName": "x"},
+    {"Id": "001xx000003DHP1AAO", "AccountId": "ID-24",
+        "Email": "contact2@example.com",
+        "FirstName": "Alice", "LastName": "y"}
+]
 
-#     @responses.activate
-#     def test_delete(self):
-#         """Test bulk delete records"""
-#         operation = 'delete'
-#         responses.add(
-#             responses.POST,
-#             re.compile(r'^https://[^/job].*/job$'),
-#             body='{"apiVersion": 42.0, "concurrencyMode": "Parallel",'
-#             '"contentType": "JSON","id": "Job-1","object": "Contact",'
-#             '"operation": "%s","state": "Open"}' % operation,
-#             status=http.OK)
-#         responses.add(
-#             responses.POST,
-#             re.compile(r'^https://[^/job].*/job/Job-1/batch$'),
-#             body='{"id": "Batch-1","jobId": "Job-1","state": "Queued"}',
-#             status=http.OK
-#         )
-#         responses.add(
-#             responses.POST,
-#             re.compile(r'^https://[^/job].*/job/Job-1$'),
-#             body='{"apiVersion" : 42.0, "concurrencyMode" : "Parallel",'
-#             '"contentType" : "JSON","id" : "Job-1","object" : "Contact",'
-#             '"operation" : "%s","state" : "Closed"}' % operation,
-#             status=http.OK
-#         )
-#         responses.add(
-#             responses.GET,
-#             re.compile(r'^https://[^/job].*/job/Job-1/batch/Batch-1$'),
-#             body='{"id": "Batch-1","jobId": "Job-1","state": "InProgress"}',
-#             status=http.OK
-#         )
-#         responses.add(
-#             responses.GET,
-#             re.compile(r'^https://[^/job].*/job/Job-1/batch/Batch-1$'),
-#             body='{"id": "Batch-1","jobId": "Job-1","state": "Completed"}',
-#             status=http.OK
-#         )
-#         responses.add(
-#             responses.GET,
-#             re.compile(
-#                 r'^https://[^/job].*/job/Job-1/batch/Batch-1/result$'),
-#             body='[{"success": true,"created": true,"id": "001xx000003DHP0AAO",'
-#             '"errors": []},{"success": true,"created": true,'
-#             '"id": "001xx000003DHP1AAO","errors": []}]',
-#             status=http.OK
-#         )
-#         data = [{
-#             'id': 'ID-1',
-#         }, {
-#             'id': 'ID-2',
-#         }]
-#         session = requests.Session()
-#         client = Salesforce(session_id=tests.SESSION_ID,
-#                             instance_url=tests.SERVER_URL,
-#                             session=session)
-#         contact = client.bulk.Contact.delete(data)
-#         self.assertEqual(self.expected, contact)
+@pytest.mark.skip
+@pytest.mark.asyncio
+async def test_delete(sf_client, mock_httpx_client):
+    _, mock_client, _ = mock_httpx_client
+    operation = 'delete'
+    body1 = {
+        "apiVersion": 42.0,
+        "concurrencyMode": "Parallel",
+        "contentType": "JSON",
+        "id": "Job-1",
+        "object": "Contact",
+        "operation": operation,
+        "state": "Open"
+    }
+    body2 = {"id": "Batch-1", "jobId": "Job-1", "state": "Queued"}
+    body3 = copy.deepcopy(body1)
+    body3["state"] = "Closed"
+    body4 = copy.deepcopy(body2)
+    body4["state"] = "InProgress"
+    body5 = copy.deepcopy(body2)
+    body5["state"] = "Completed"
+    body6 = [{
+            "success": True,
+            "created": True,
+            "id": "001xx000003DHP0AAO",
+            "errors": []
+        }, {
+            "success": True,
+            "created": True,
+            "id": "001xx000003DHP1AAO",
+            "errors": []
+        }]
+    all_bodies = [body1, body2, body3, body4, body5, body6]
+    responses = [
+        httpx.Response(200, content=json.dumps(body)) for body in all_bodies
+    ]
+    mock_client.request.side_effect = mock.AsyncMock(side_effect=responses)
+    data = [{
+        'id': 'ID-1',
+    }, {
+        'id': 'ID-2',
+    }]
+    result = await sf_client.bulk.Contact.delete(data, wait=0.1)
+    assert EXPECTED_RESULT == result
 
-#     @responses.activate
-#     def test_insert(self):
-#         """Test bulk insert records"""
-#         operation = 'insert'
-#         responses.add(
-#             responses.POST,
-#             re.compile(r'^https://[^/job].*/job$'),
-#             body='{"apiVersion": 42.0, "concurrencyMode": "Parallel",'
-#             '"contentType": "JSON","id": "Job-1","object": "Contact",'
-#             '"operation": "%s","state": "Open"}' % operation,
-#             status=http.OK)
-#         responses.add(
-#             responses.POST,
-#             re.compile(r'^https://[^/job].*/job/Job-1/batch$'),
-#             body='{"id": "Batch-1","jobId": "Job-1","state": "Queued"}',
-#             status=http.OK
-#         )
-#         responses.add(
-#             responses.POST,
-#             re.compile(r'^https://[^/job].*/job/Job-1$'),
-#             body='{"apiVersion" : 42.0, "concurrencyMode" : "Parallel",'
-#             '"contentType" : "JSON","id" : "Job-1","object" : "Contact",'
-#             '"operation" : "%s","state" : "Closed"}' % operation,
-#             status=http.OK
-#         )
-#         responses.add(
-#             responses.GET,
-#             re.compile(r'^https://[^/job].*/job/Job-1/batch/Batch-1$'),
-#             body='{"id": "Batch-1","jobId": "Job-1","state": "InProgress"}',
-#             status=http.OK
-#         )
-#         responses.add(
-#             responses.GET,
-#             re.compile(r'^https://[^/job].*/job/Job-1/batch/Batch-1$'),
-#             body='{"id": "Batch-1","jobId": "Job-1","state": "Completed"}',
-#             status=http.OK
-#         )
-#         responses.add(
-#             responses.GET,
-#             re.compile(
-#                 r'^https://[^/job].*/job/Job-1/batch/Batch-1/result$'),
-#             body='[{"success": true,"created": true,"id": "001xx000003DHP0AAO",'
-#             '"errors": []},{"success": true,"created": true,'
-#             '"id": "001xx000003DHP1AAO","errors": []}]',
-#             status=http.OK
-#         )
-
-#         data = [{
-#             'AccountId': 'ID-1',
-#             'Email': 'contact1@example.com',
-#             'FirstName': 'Bob',
-#             'LastName': 'x'
-#         }, {
-#             'AccountId': 'ID-2',
-#             'Email': 'contact2@example.com',
-#             'FirstName': 'Alice',
-#             'LastName': 'y'
-#         }]
-#         session = requests.Session()
-#         client = Salesforce(session_id=tests.SESSION_ID,
-#                             instance_url=tests.SERVER_URL,
-#                             session=session)
-#         contact = client.bulk.Contact.insert(data)
-#         self.assertEqual(self.expected, contact)
-
-#     @responses.activate
-#     def test_upsert(self):
-#         """Test bulk upsert records"""
-#         operation = 'upsert'
-#         responses.add(
-#             responses.POST,
-#             re.compile(r'^https://[^/job].*/job$'),
-#             body='{"apiVersion": 42.0, "concurrencyMode": "Parallel",'
-#             '"contentType": "JSON","id": "Job-1","object": "Contact",'
-#             '"operation": "%s","state": "Open"}' % operation,
-#             status=http.OK)
-#         responses.add(
-#             responses.POST,
-#             re.compile(r'^https://[^/job].*/job/Job-1/batch$'),
-#             body='{"id": "Batch-1","jobId": "Job-1","state": "Queued"}',
-#             status=http.OK
-#         )
-#         responses.add(
-#             responses.POST,
-#             re.compile(r'^https://[^/job].*/job/Job-1$'),
-#             body='{"apiVersion" : 42.0, "concurrencyMode" : "Parallel",'
-#             '"contentType" : "JSON","id" : "Job-1","object" : "Contact",'
-#             '"operation" : "%s","state" : "Closed"}' % operation,
-#             status=http.OK
-#         )
-#         responses.add(
-#             responses.GET,
-#             re.compile(r'^https://[^/job].*/job/Job-1/batch/Batch-1$'),
-#             body='{"id": "Batch-1","jobId": "Job-1","state": "InProgress"}',
-#             status=http.OK
-#         )
-#         responses.add(
-#             responses.GET,
-#             re.compile(r'^https://[^/job].*/job/Job-1/batch/Batch-1$'),
-#             body='{"id": "Batch-1","jobId": "Job-1","state": "Completed"}',
-#             status=http.OK
-#         )
-#         responses.add(
-#             responses.GET,
-#             re.compile(
-#                 r'^https://[^/job].*/job/Job-1/batch/Batch-1/result$'),
-#             body='[{"success": true,"created": true,"id": "001xx000003DHP0AAO",'
-#             '"errors": []},{"success": true,"created": true,'
-#             '"id": "001xx000003DHP1AAO","errors": []}]',
-#             status=http.OK
-#         )
-
-#         data = [{
-#             'Custom_Id__c': 'CustomID1',
-#             'AccountId': 'ID-13',
-#             'Email': 'contact1@example.com',
-#             'FirstName': 'Bob',
-#             'LastName': 'x'
-#         }, {
-#             'Custom_Id__c': 'CustomID2',
-#             'AccountId': 'ID-24',
-#             'Email': 'contact2@example.com',
-#             'FirstName': 'Alice',
-#             'LastName': 'y'
-#         }]
-#         session = requests.Session()
-#         client = Salesforce(session_id=tests.SESSION_ID,
-#                             instance_url=tests.SERVER_URL,
-#                             session=session)
-#         contact = client.bulk.Contact.upsert(data, 'Custom_Id__c')
-#         self.assertEqual(self.expected, contact)
-
-#     @responses.activate
-#     def test_update(self):
-#         """Test bulk update records"""
-#         operation = 'upsert'
-#         responses.add(
-#             responses.POST,
-#             re.compile(r'^https://[^/job].*/job$'),
-#             body='{"apiVersion": 42.0, "concurrencyMode": "Parallel",'
-#             '"contentType": "JSON","id": "Job-1","object": "Contact",'
-#             '"operation": "%s","state": "Open"}' % operation,
-#             status=http.OK)
-#         responses.add(
-#             responses.POST,
-#             re.compile(r'^https://[^/job].*/job/Job-1/batch$'),
-#             body='{"id": "Batch-1","jobId": "Job-1","state": "Queued"}',
-#             status=http.OK
-#         )
-#         responses.add(
-#             responses.POST,
-#             re.compile(r'^https://[^/job].*/job/Job-1$'),
-#             body='{"apiVersion" : 42.0, "concurrencyMode" : "Parallel",'
-#             '"contentType" : "JSON","id" : "Job-1","object" : "Contact",'
-#             '"operation" : "%s","state" : "Closed"}' % operation,
-#             status=http.OK
-#         )
-#         responses.add(
-#             responses.GET,
-#             re.compile(r'^https://[^/job].*/job/Job-1/batch/Batch-1$'),
-#             body='{"id": "Batch-1","jobId": "Job-1","state": "InProgress"}',
-#             status=http.OK
-#         )
-#         responses.add(
-#             responses.GET,
-#             re.compile(r'^https://[^/job].*/job/Job-1/batch/Batch-1$'),
-#             body='{"id": "Batch-1","jobId": "Job-1","state": "Completed"}',
-#             status=http.OK
-#         )
-#         responses.add(
-#             responses.GET,
-#             re.compile(
-#                 r'^https://[^/job].*/job/Job-1/batch/Batch-1/result$'),
-#             body='[{"success": true,"created": true,"id": "001xx000003DHP0AAO",'
-#             '"errors": []},{"success": true,"created": true,'
-#             '"id": "001xx000003DHP1AAO","errors": []}]',
-#             status=http.OK
-#         )
-
-#         data = [{
-#             'Id': '001xx000003DHP0AAO',
-#             'AccountId': 'ID-13',
-#             'Email': 'contact1@example.com',
-#             'FirstName': 'Bob',
-#             'LastName': 'x'
-#         }, {
-#             'Id': '001xx000003DHP1AAO',
-#             'AccountId': 'ID-24',
-#             'Email': 'contact2@example.com',
-#             'FirstName': 'Alice',
-#             'LastName': 'y'
-#         }]
-#         session = requests.Session()
-#         client = Salesforce(session_id=tests.SESSION_ID,
-#                             instance_url=tests.SERVER_URL,
-#                             session=session)
-#         contact = client.bulk.Contact.update(data)
-#         self.assertEqual(self.expected, contact)
-
-#     @responses.activate
-#     def test_query(self):
-#         """Test bulk query records"""
-#         operation = 'query'
-#         responses.add(
-#             responses.POST,
-#             re.compile(r'^https://[^/job].*/job$'),
-#             body='{"apiVersion": 42.0, "concurrencyMode": "Parallel",'
-#             '"contentType": "JSON","id": "Job-1","object": "Contact",'
-#             '"operation": "%s","state": "Open"}' % operation,
-#             status=http.OK)
-#         responses.add(
-#             responses.POST,
-#             re.compile(r'^https://[^/job].*/job/Job-1/batch$'),
-#             body='{"id": "Batch-1","jobId": "Job-1","state": "Queued"}',
-#             status=http.OK
-#         )
-#         responses.add(
-#             responses.POST,
-#             re.compile(r'^https://[^/job].*/job/Job-1$'),
-#             body='{"apiVersion" : 42.0, "concurrencyMode" : "Parallel",'
-#             '"contentType" : "JSON","id" : "Job-1","object" : "Contact",'
-#             '"operation" : "%s","state" : "Closed"}' % operation,
-#             status=http.OK
-#         )
-#         responses.add(
-#             responses.GET,
-#             re.compile(r'^https://[^/job].*/job/Job-1/batch/Batch-1$'),
-#             body='{"id": "Batch-1","jobId": "Job-1","state": "InProgress"}',
-#             status=http.OK
-#         )
-#         responses.add(
-#             responses.GET,
-#             re.compile(r'^https://[^/job].*/job/Job-1/batch/Batch-1$'),
-#             body='{"id": "Batch-1","jobId": "Job-1","state": "Completed"}',
-#             status=http.OK
-#         )
-#         responses.add(
-#             responses.GET,
-#             re.compile(
-#                 r'^https://[^/job].*/job/Job-1/batch/Batch-1/result$'),
-#             body='["752x000000000F1","752x000000000F2"]',
-#             status=http.OK
-#         )
-
-#         responses.add(
-#             responses.GET,
-#             re.compile(r"""^https://[^/job].*/job/Job-1/batch/Batch-1/result
-#             /752x000000000F1$""", re.X),
-#             body='[{"Id": "001xx000003DHP0AAO", "AccountId": "ID-13",'
-#             '"Email": "contact1@example.com","FirstName": "Bob",'
-#             '"LastName": "x"},{"Id": "001xx000003DHP1AAO",'
-#             '"AccountId": "ID-24","Email": "contact2@example.com",'
-#             '"FirstName": "Alice","LastName": "y"}]',
-#             status=http.OK
-#         )
-#         responses.add(
-#             responses.GET,
-#             re.compile(
-#                 r"""^https://[^/job].*/job/Job-1/batch/Batch-1/result
-#                 /752x000000000F2$""", re.X),
-#             body='[{"Id": "001xx000003DHP0AAO", "AccountId": "ID-13",'
-#             '"Email": "contact1@example.com","FirstName": "Bob",'
-#             '"LastName": "x"},{"Id": "001xx000003DHP1AAO",'
-#             '"AccountId": "ID-24","Email": "contact2@example.com",'
-#             '"FirstName": "Alice","LastName": "y"}]',
-#             status=http.OK
-#         )
-
-#         data = 'SELECT Id,AccountId,Email,FirstName,LastName FROM Contact'
-#         session = requests.Session()
-#         client = Salesforce(session_id=tests.SESSION_ID,
-#                             instance_url=tests.SERVER_URL,
-#                             session=session)
-#         contact = client.bulk.Contact.query(data)
-#         self.assertEqual(self.expected_query, contact)
-
-#     @responses.activate
-#     def test_query_lazy(self):
-#         """Test bulk query records"""
-#         operation = 'query'
-#         responses.add(
-#             responses.POST,
-#             re.compile(r'^https://[^/job].*/job$'),
-#             body='{"apiVersion": 42.0, "concurrencyMode": "Parallel",'
-#             '"contentType": "JSON","id": "Job-1","object": "Contact",'
-#             '"operation": "%s","state": "Open"}' % operation,
-#             status=http.OK)
-#         responses.add(
-#             responses.POST,
-#             re.compile(r'^https://[^/job].*/job/Job-1/batch$'),
-#             body='{"id": "Batch-1","jobId": "Job-1","state": "Queued"}',
-#             status=http.OK
-#         )
-#         responses.add(
-#             responses.POST,
-#             re.compile(r'^https://[^/job].*/job/Job-1$'),
-#             body='{"apiVersion" : 42.0, "concurrencyMode" : "Parallel",'
-#             '"contentType" : "JSON","id" : "Job-1","object" : "Contact",'
-#             '"operation" : "%s","state" : "Closed"}' % operation,
-#             status=http.OK
-#         )
-#         responses.add(
-#             responses.GET,
-#             re.compile(r'^https://[^/job].*/job/Job-1/batch/Batch-1$'),
-#             body='{"id": "Batch-1","jobId": "Job-1","state": "InProgress"}',
-#             status=http.OK
-#         )
-#         responses.add(
-#             responses.GET,
-#             re.compile(r'^https://[^/job].*/job/Job-1/batch/Batch-1$'),
-#             body='{"id": "Batch-1","jobId": "Job-1","state": "Completed"}',
-#             status=http.OK
-#         )
-#         responses.add(
-#             responses.GET,
-#             re.compile(
-#                 r'^https://[^/job].*/job/Job-1/batch/Batch-1/result$'),
-#             body='["752x000000000F1","752x000000000F2"]',
-#             status=http.OK
-#         )
-
-#         responses.add(
-#             responses.GET,
-#             re.compile(r"""^https://[^/job].*/job/Job-1/batch/Batch-1/result
-#             /752x000000000F1$""", re.X),
-#             body='[{"Id": "001xx000003DHP0AAO", "AccountId": "ID-13",'
-#             '"Email": "contact1@example.com","FirstName": "Bob",'
-#             '"LastName": "x"},{"Id": "001xx000003DHP1AAO",'
-#             '"AccountId": "ID-24","Email": "contact2@example.com",'
-#             '"FirstName": "Alice","LastName": "y"}]',
-#             status=http.OK
-#         )
-#         responses.add(
-#             responses.GET,
-#             re.compile(
-#                 r"""^https://[^/job].*/job/Job-1/batch/Batch-1/result
-#                 /752x000000000F2$""", re.X),
-#             body='[{"Id": "001xx000003DHP0AAO", "AccountId": "ID-13",'
-#             '"Email": "contact1@example.com","FirstName": "Bob",'
-#             '"LastName": "x"},{"Id": "001xx000003DHP1AAO",'
-#             '"AccountId": "ID-24","Email": "contact2@example.com",'
-#             '"FirstName": "Alice","LastName": "y"}]',
-#             status=http.OK
-#         )
-
-#         data = 'SELECT Id,AccountId,Email,FirstName,LastName FROM Contact'
-#         session = requests.Session()
-#         client = Salesforce(session_id=tests.SESSION_ID,
-#                             instance_url=tests.SERVER_URL,
-#                             session=session)
-
-#         contact = []
-#         for list_results in client.bulk.Contact.query(data, True):
-#             contact.extend(list_results)
-
-#         self.assertEqual(self.expected_query, contact)
-
-#     @responses.activate
-#     def test_query_all(self):
-#         """Test bulk queryAll records"""
-#         operation = 'queryAll'
-#         responses.add(
-#             responses.POST,
-#             re.compile(r'^https://[^/job].*/job$'),
-#             body='{"apiVersion": 42.0, "concurrencyMode": "Parallel",'
-#             '"contentType": "JSON","id": "Job-1","object": "Contact",'
-#             '"operation": "%s","state": "Open"}' % operation,
-#             status=http.OK)
-#         responses.add(
-#             responses.POST,
-#             re.compile(r'^https://[^/job].*/job/Job-1/batch$'),
-#             body='{"id": "Batch-1","jobId": "Job-1","state": "Queued"}',
-#             status=http.OK
-#         )
-#         responses.add(
-#             responses.POST,
-#             re.compile(r'^https://[^/job].*/job/Job-1$'),
-#             body='{"apiVersion" : 42.0, "concurrencyMode" : "Parallel",'
-#             '"contentType" : "JSON","id" : "Job-1","object" : "Contact",'
-#             '"operation" : "%s","state" : "Closed"}' % operation,
-#             status=http.OK
-#         )
-#         responses.add(
-#             responses.GET,
-#             re.compile(r'^https://[^/job].*/job/Job-1/batch/Batch-1$'),
-#             body='{"id": "Batch-1","jobId": "Job-1","state": "InProgress"}',
-#             status=http.OK
-#         )
-#         responses.add(
-#             responses.GET,
-#             re.compile(r'^https://[^/job].*/job/Job-1/batch/Batch-1$'),
-#             body='{"id": "Batch-1","jobId": "Job-1","state": "Completed"}',
-#             status=http.OK
-#         )
-#         responses.add(
-#             responses.GET,
-#             re.compile(
-#                 r'^https://[^/job].*/job/Job-1/batch/Batch-1/result$'),
-#             body='["752x000000000F1","752x000000000F2"]',
-#             status=http.OK
-#         )
-#         responses.add(
-#             responses.GET,
-#             re.compile(r"""^https://[^/job].*/job/Job-1/batch/Batch-1/result
-#             /752x000000000F1$""", re.X),
-#             body='[{"Id": "001xx000003DHP0AAO", "AccountId": "ID-13",'
-#             '"Email": "contact1@example.com","FirstName": "Bob",'
-#             '"LastName": "x"},{"Id": "001xx000003DHP1AAO",'
-#             '"AccountId": "ID-24","Email": "contact2@example.com",'
-#             '"FirstName": "Alice","LastName": "y"}]',
-#             status=http.OK
-#         )
-#         responses.add(
-#             responses.GET,
-#             re.compile(
-#                 r"""^https://[^/job].*/job/Job-1/batch/Batch-1/result
-#                 /752x000000000F2$""", re.X),
-#             body='[{"Id": "001xx000003DHP0AAO", "AccountId": "ID-13",'
-#             '"Email": "contact1@example.com","FirstName": "Bob",'
-#             '"LastName": "x"},{"Id": "001xx000003DHP1AAO",'
-#             '"AccountId": "ID-24","Email": "contact2@example.com",'
-#             '"FirstName": "Alice","LastName": "y"}]',
-#             status=http.OK
-#         )
-
-#         data = 'SELECT Id,AccountId,Email,FirstName,LastName FROM Contact'
-#         session = requests.Session()
-#         client = Salesforce(session_id=tests.SESSION_ID,
-#                             instance_url=tests.SERVER_URL,
-#                             session=session)
-#         contact = client.bulk.Contact.query_all(data)
-#         self.assertEqual(self.expected_query, contact)

--- a/simple_salesforce/tests/test_aio/test_bulk.py
+++ b/simple_salesforce/tests/test_aio/test_bulk.py
@@ -20,46 +20,55 @@ def test_bulk_type(sf_client, constants):
     contact = sf_client.bulk.Contact
     assert contact.bulk_url == sf_client.bulk_url
     assert constants["BULK_HEADERS"] == contact.headers
-    assert 'Contact' == contact.object_name
+    assert "Contact" == contact.object_name
 
 
 EXPECTED_RESULT = [
-    {
-        "success": True,
-        "created": True,
-        "id": "001xx000003DHP0AAO",
-        "errors": []
-    },
-    {
-        "success": True,
-        "created": True,
-        "id": "001xx000003DHP1AAO",
-        "errors": []
-    }
+    {"success": True, "created": True, "id": "001xx000003DHP0AAO", "errors": []},
+    {"success": True, "created": True, "id": "001xx000003DHP1AAO", "errors": []},
 ]
 EXPECTED_QUERY = [
-    {"Id": "001xx000003DHP0AAO", "AccountId": "ID-13",
+    {
+        "Id": "001xx000003DHP0AAO",
+        "AccountId": "ID-13",
         "Email": "contact1@example.com",
-        "FirstName": "Bob", "LastName": "x"},
-    {"Id": "001xx000003DHP1AAO", "AccountId": "ID-24",
+        "FirstName": "Bob",
+        "LastName": "x",
+    },
+    {
+        "Id": "001xx000003DHP1AAO",
+        "AccountId": "ID-24",
         "Email": "contact2@example.com",
-        "FirstName": "Alice", "LastName": "y"},
-    {"Id": "001xx000003DHP0AAO", "AccountId": "ID-13",
+        "FirstName": "Alice",
+        "LastName": "y",
+    },
+    {
+        "Id": "001xx000003DHP0AAO",
+        "AccountId": "ID-13",
         "Email": "contact1@example.com",
-        "FirstName": "Bob", "LastName": "x"},
-    {"Id": "001xx000003DHP1AAO", "AccountId": "ID-24",
+        "FirstName": "Bob",
+        "LastName": "x",
+    },
+    {
+        "Id": "001xx000003DHP1AAO",
+        "AccountId": "ID-24",
         "Email": "contact2@example.com",
-        "FirstName": "Alice", "LastName": "y"}
+        "FirstName": "Alice",
+        "LastName": "y",
+    },
 ]
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("operation,method_name", (
-    ("delete", "delete"),
-    ("insert", "insert"),
-    ("update", "update"),
-    ("hardDelete", "hard_delete"),
-))
+@pytest.mark.parametrize(
+    "operation,method_name",
+    (
+        ("delete", "delete"),
+        ("insert", "insert"),
+        ("update", "update"),
+        ("hardDelete", "hard_delete"),
+    ),
+)
 async def test_insert(operation, method_name, sf_client, mock_httpx_client):
     """Test bulk insert records"""
     _, mock_client, _ = mock_httpx_client
@@ -70,7 +79,7 @@ async def test_insert(operation, method_name, sf_client, mock_httpx_client):
         "id": "Job-1",
         "object": "Contact",
         "operation": operation,
-        "state": "Open"
+        "state": "Open",
     }
     body2 = {"id": "Batch-1", "jobId": "Job-1", "state": "Queued"}
     body3 = copy.deepcopy(body1)
@@ -79,34 +88,28 @@ async def test_insert(operation, method_name, sf_client, mock_httpx_client):
     body4["state"] = "InProgress"
     body5 = copy.deepcopy(body2)
     body5["state"] = "Completed"
-    body6 = [{
-            "success": True,
-            "created": True,
-            "id": "001xx000003DHP0AAO",
-            "errors": []
-        }, {
-            "success": True,
-            "created": True,
-            "id": "001xx000003DHP1AAO",
-            "errors": []
-        }]
+    body6 = [
+        {"success": True, "created": True, "id": "001xx000003DHP0AAO", "errors": []},
+        {"success": True, "created": True, "id": "001xx000003DHP1AAO", "errors": []},
+    ]
     body7 = {}
     all_bodies = [body1, body2, body3, body4, body5, body6, body7]
-    responses = [
-        httpx.Response(200, content=json.dumps(body)) for body in all_bodies
-    ]
+    responses = [httpx.Response(200, content=json.dumps(body)) for body in all_bodies]
     mock_client.request.side_effect = mock.AsyncMock(side_effect=responses)
-    data = [{
-        'AccountId': 'ID-1',
-        'Email': 'contact1@example.com',
-        'FirstName': 'Bob',
-        'LastName': 'x'
-    }, {
-        'AccountId': 'ID-2',
-        'Email': 'contact2@example.com',
-        'FirstName': 'Alice',
-        'LastName': 'y'
-    }]
+    data = [
+        {
+            "AccountId": "ID-1",
+            "Email": "contact1@example.com",
+            "FirstName": "Bob",
+            "LastName": "x",
+        },
+        {
+            "AccountId": "ID-2",
+            "Email": "contact2@example.com",
+            "FirstName": "Alice",
+            "LastName": "y",
+        },
+    ]
     function = getattr(sf_client.bulk.Contact, method_name)
     result = await function(data, wait=0.1)
     assert EXPECTED_RESULT == result
@@ -116,7 +119,7 @@ async def test_insert(operation, method_name, sf_client, mock_httpx_client):
 async def test_upsert(sf_client, mock_httpx_client):
     """Test bulk upsert records"""
     _, mock_client, _ = mock_httpx_client
-    operation = 'delete'
+    operation = "delete"
     body1 = {
         "apiVersion": 42.0,
         "concurrencyMode": "Parallel",
@@ -124,7 +127,7 @@ async def test_upsert(sf_client, mock_httpx_client):
         "id": "Job-1",
         "object": "Contact",
         "operation": operation,
-        "state": "Open"
+        "state": "Open",
     }
     body2 = {"id": "Batch-1", "jobId": "Job-1", "state": "Queued"}
     body3 = copy.deepcopy(body1)
@@ -133,27 +136,226 @@ async def test_upsert(sf_client, mock_httpx_client):
     body4["state"] = "InProgress"
     body5 = copy.deepcopy(body2)
     body5["state"] = "Completed"
-    body6 = [{
-            "success": True,
-            "created": True,
-            "id": "001xx000003DHP0AAO",
-            "errors": []
-        }, {
-            "success": True,
-            "created": True,
-            "id": "001xx000003DHP1AAO",
-            "errors": []
-        }]
+    body6 = [
+        {"success": True, "created": True, "id": "001xx000003DHP0AAO", "errors": []},
+        {"success": True, "created": True, "id": "001xx000003DHP1AAO", "errors": []},
+    ]
     body7 = {}
     all_bodies = [body1, body2, body3, body4, body5, body6, body7]
-    responses = [
-        httpx.Response(200, content=json.dumps(body)) for body in all_bodies
-    ]
+    responses = [httpx.Response(200, content=json.dumps(body)) for body in all_bodies]
     mock_client.request.side_effect = mock.AsyncMock(side_effect=responses)
-    data = [{
-        'id': 'ID-1',
-    }, {
-        'id': 'ID-2',
-    }]
+    data = [{"id": "ID-1",}, {"id": "ID-2",}]
     result = await sf_client.bulk.Contact.upsert(data, "some-field", wait=0.1)
     assert EXPECTED_RESULT == result
+
+
+@pytest.mark.asyncio
+async def test_query(mock_httpx_client, sf_client):
+    """Test bulk query"""
+    _, mock_client, _ = mock_httpx_client
+    operation = "query"
+    body1 = {
+        "apiVersion": 42.0,
+        "concurrencyMode": "Parallel",
+        "contentType": "JSON",
+        "id": "Job-1",
+        "object": "Contact",
+        "operation": operation,
+        "state": "Open",
+    }
+    body2 = {"id": "Batch-1", "jobId": "Job-1", "state": "Queued"}
+    body3 = copy.deepcopy(body1)
+    body3["state"] = "Closed"
+    body4 = copy.deepcopy(body2)
+    body4["state"] = "InProgress"
+    body5 = copy.deepcopy(body2)
+    body5["state"] = "Completed"
+    body6 = ["752x000000000F1", "752x000000000F2"]
+    body7 = [
+        {
+            "Id": "001xx000003DHP0AAO",
+            "AccountId": "ID-13",
+            "Email": "contact1@example.com",
+            "FirstName": "Bob",
+            "LastName": "x",
+        },
+        {
+            "Id": "001xx000003DHP1AAO",
+            "AccountId": "ID-24",
+            "Email": "contact2@example.com",
+            "FirstName": "Alice",
+            "LastName": "y",
+        },
+    ]
+    body8 = [
+        {
+            "Id": "001xx000003DHP0AAO",
+            "AccountId": "ID-13",
+            "Email": "contact1@example.com",
+            "FirstName": "Bob",
+            "LastName": "x",
+        },
+        {
+            "Id": "001xx000003DHP1AAO",
+            "AccountId": "ID-24",
+            "Email": "contact2@example.com",
+            "FirstName": "Alice",
+            "LastName": "y",
+        },
+    ]
+    all_bodies = [body1, body2, body3, body4, body5, body6, body7, body8]
+    responses = [httpx.Response(200, content=json.dumps(body)) for body in all_bodies]
+    mock_client.request.side_effect = mock.AsyncMock(side_effect=responses)
+    data = "SELECT Id,AccountId,Email,FirstName,LastName FROM Contact"
+    result = await sf_client.bulk.Contact.query(
+        data, wait=0.1, lazy_operation=False
+    )
+    assert body7[0] in result
+    assert body7[1] in result
+    assert body8[0] in result
+    assert body8[1] in result
+
+
+@pytest.mark.asyncio
+async def test_query_all(mock_httpx_client, sf_client):
+    """Test bulk query all"""
+    _, mock_client, _ = mock_httpx_client
+    operation = "queryAll"
+    body1 = {
+        "apiVersion": 42.0,
+        "concurrencyMode": "Parallel",
+        "contentType": "JSON",
+        "id": "Job-1",
+        "object": "Contact",
+        "operation": operation,
+        "state": "Open",
+    }
+    body2 = {"id": "Batch-1", "jobId": "Job-1", "state": "Queued"}
+    body3 = copy.deepcopy(body1)
+    body3["state"] = "Closed"
+    body4 = copy.deepcopy(body2)
+    body4["state"] = "InProgress"
+    body5 = copy.deepcopy(body2)
+    body5["state"] = "Completed"
+    body6 = ["752x000000000F1", "752x000000000F2"]
+    body7 = [
+        {
+            "Id": "001xx000003DHP0AAO",
+            "AccountId": "ID-13",
+            "Email": "contact1@example.com",
+            "FirstName": "Bob",
+            "LastName": "x",
+        },
+        {
+            "Id": "001xx000003DHP1AAO",
+            "AccountId": "ID-24",
+            "Email": "contact2@example.com",
+            "FirstName": "Alice",
+            "LastName": "y",
+        },
+    ]
+    body8 = [
+        {
+            "Id": "001xx000003DHP0AAO",
+            "AccountId": "ID-13",
+            "Email": "contact1@example.com",
+            "FirstName": "Bob",
+            "LastName": "x",
+        },
+        {
+            "Id": "001xx000003DHP1AAO",
+            "AccountId": "ID-24",
+            "Email": "contact2@example.com",
+            "FirstName": "Alice",
+            "LastName": "y",
+        },
+    ]
+    all_bodies = [body1, body2, body3, body4, body5, body6, body7, body8]
+    responses = [httpx.Response(200, content=json.dumps(body)) for body in all_bodies]
+    mock_client.request.side_effect = mock.AsyncMock(side_effect=responses)
+    data = "SELECT Id,AccountId,Email,FirstName,LastName FROM Contact"
+    result = await sf_client.bulk.Contact.query_all(
+        data, wait=0.1, lazy_operation=False
+    )
+    assert body7[0] in result
+    assert body7[1] in result
+    assert body8[0] in result
+    assert body8[1] in result
+
+
+@pytest.mark.asyncio
+async def test_query_lazy(mock_httpx_client, sf_client):
+    """Test lazy bulk query"""
+    _, mock_client, _ = mock_httpx_client
+    operation = "queryAll"
+    body1 = {
+        "apiVersion": 42.0,
+        "concurrencyMode": "Parallel",
+        "contentType": "JSON",
+        "id": "Job-1",
+        "object": "Contact",
+        "operation": operation,
+        "state": "Open",
+    }
+    body2 = {"id": "Batch-1", "jobId": "Job-1", "state": "Queued"}
+    body3 = copy.deepcopy(body1)
+    body3["state"] = "Closed"
+    body4 = copy.deepcopy(body2)
+    body4["state"] = "InProgress"
+    body5 = copy.deepcopy(body2)
+    body5["state"] = "Completed"
+    body6 = ["752x000000000F1", "752x000000000F2"]
+    body7 = [
+        {
+            "Id": "001xx000003DHP0AAO",
+            "AccountId": "ID-13",
+            "Email": "contact1@example.com",
+            "FirstName": "Bob",
+            "LastName": "x",
+        },
+        {
+            "Id": "001xx000003DHP1AAO",
+            "AccountId": "ID-24",
+            "Email": "contact2@example.com",
+            "FirstName": "Alice",
+            "LastName": "y",
+        },
+    ]
+    body8 = [
+        {
+            "Id": "001xx000003DHP0AAO",
+            "AccountId": "ID-15",
+            "Email": "contact1@example.com",
+            "FirstName": "Bob",
+            "LastName": "x",
+        },
+        {
+            "Id": "001xx000003DHP1AAO",
+            "AccountId": "ID-26",
+            "Email": "contact2@example.com",
+            "FirstName": "Alice",
+            "LastName": "y",
+        },
+    ]
+    all_bodies = [body1, body2, body3, body4, body5, body6, body7, body8]
+    responses = [httpx.Response(200, content=json.dumps(body)) for body in all_bodies]
+    mock_client.request.side_effect = mock.AsyncMock(side_effect=responses)
+    data = "SELECT Id,AccountId,Email,FirstName,LastName FROM Contact"
+    result = await sf_client.bulk.Contact.query_all(
+        data, wait=0.1, lazy_operation=True
+    )
+    assert body7[0] in result[0]
+    assert body7[1] in result[0]
+    assert body8[0] in result[1]
+    assert body8[1] in result[1]
+    # [[{'Id': '001xx000003DHP0AAO', 'AccountId': 'ID-13',
+    # 'Email': 'contact1@example.com', 'FirstName': 'Bob',
+    # 'LastName': 'x'}, {'Id': '001xx000003DHP1AAO',
+    # 'AccountId': 'ID-24', 'Email': 'contact2@example.com',
+    # 'FirstName': 'Alice', 'LastName': 'y'}],
+    # [{'Id': '001xx000003DHP0AAO', 'AccountId': 'ID-13',
+    # 'Email': 'contact1@example.com', 'FirstName': 'Bob',
+    # 'LastName': 'x'}, {'Id': '001xx000003DHP1AAO',
+    # 'AccountId': 'ID-24', 'Email': 'contact2@example.com',
+    # 'FirstName': 'Alice', 'LastName': 'y'}]]
+

--- a/simple_salesforce/tests/test_aio/test_login.py
+++ b/simple_salesforce/tests/test_aio/test_login.py
@@ -1,224 +1,278 @@
 """Tests for login.py"""
-
-import http.client as http
+import json
 import os
-import re
-import unittest
-import warnings
-from unittest.mock import Mock, patch
 from urllib.parse import urlparse
+import warnings
 
-import requests
-import responses
-from simple_salesforce import tests
+import httpx
+import pytest
+
 from simple_salesforce.exceptions import SalesforceAuthenticationFailed
-from simple_salesforce.login import SalesforceLogin
+from simple_salesforce.aio.login import SalesforceLogin
 
 
-# class TestSalesforceLogin(unittest.TestCase):
-#     """Tests for the SalesforceLogin function"""
+PARENT_DIR = os.path.dirname(os.path.dirname(__file__))
+SOAP_URL = "https://login.salesforce.com/services/Soap/u/"
+OAUTH_TOKEN_URL = "https://login.salesforce.com/services/oauth2/token"
 
-#     def setUp(self):
-#         """Setup the SalesforceLogin tests"""
-#         request_patcher = patch('simple_salesforce.login.requests')
-#         self.mockrequest = request_patcher.start()
-#         self.addCleanup(request_patcher.stop)
 
-#     def _test_login_success(self, url_regex, salesforce_login_kwargs,
-#                             response_body=tests.LOGIN_RESPONSE_SUCCESS):
-#         """Test SalesforceLogin with one set of arguments.
+@pytest.mark.asyncio
+async def test_default_domain_success(constants, mock_httpx_client):
+    """Test login for default domain"""
+    _, mock_client, inner = mock_httpx_client
+    happy_result = httpx.Response(
+        200,
+        content=constants["LOGIN_RESPONSE_SUCCESS"]
+    )
+    inner(happy_result)
+    mock_client.custom_session_attrib = "X-1-2-3"
 
-#         Mock login requests at url_regex, returning a successful response,
-#         response_body. Check that the fake-login process works when passing
-#         salesforce_login_kwargs as keyword arguments to SalesforceLogin in
-#         addition to the mocked session and a default username.
-#         """
-#         responses.add(
-#             responses.POST,
-#             url_regex,
-#             body=response_body,
-#             status=http.OK
-#         )
-#         session_state = {
-#             'used': False,
-#         }
+    (session_id, instance_url) = await SalesforceLogin(
+        session=mock_client,
+        username='foo@bar.com',
+        password='password',
+        security_token='token'
+    )
+    assert session_id == constants["SESSION_ID"]
+    assert instance_url == urlparse(constants["INSTANCE_URL"]).netloc
+    assert len(mock_client.method_calls) == 1
+    call = mock_client.method_calls[0]
+    assert call[0] == "post"
+    assert call[1][0].startswith(SOAP_URL)
+    assert "SOAPAction" in call[2]["headers"]
+    assert call[2]["headers"]["SOAPAction"] == "login"
 
-#         # pylint: disable=missing-docstring,unused-argument
-#         def on_response(*args, **kwargs):
-#             session_state['used'] = True
 
-#         session = requests.Session()
-#         session.hooks = {
-#             'response': on_response,
-#         }
-#         session_id, instance = SalesforceLogin(
-#             session=session,
-#             username='foo@bar.com',
-#             **salesforce_login_kwargs
-#         )
-#         self.assertTrue(session_state['used'])
-#         self.assertEqual(session_id, tests.SESSION_ID)
-#         self.assertEqual(instance, urlparse(tests.SERVER_URL).netloc)
+@pytest.mark.asyncio
+async def test_custom_domain_success(constants, mock_httpx_client):
+    """Test login for custom domain"""
+    _, mock_client, inner = mock_httpx_client
+    happy_result = httpx.Response(
+        200,
+        content=constants["LOGIN_RESPONSE_SUCCESS"]
+    )
+    inner(happy_result)
+    mock_client.custom_session_attrib = "X-1-2-3"
 
-#     @responses.activate
-#     def test_default_domain_success(self):
-#         """Test default domain logic and login"""
-#         login_args = {'password': 'password', 'security_token': 'token'}
-#         self._test_login_success(re.compile(r'^https://login.*$'), login_args)
+    (session_id, instance_url) = await SalesforceLogin(
+        session=mock_client,
+        username='foo@bar.com',
+        password='password',
+        security_token='token',
+        domain='testdomain.my'
+    )
+    assert session_id == constants["SESSION_ID"]
+    assert instance_url == urlparse(constants["INSTANCE_URL"]).netloc
+    assert len(mock_client.method_calls) == 1
+    call = mock_client.method_calls[0]
+    assert call[0] == "post"
+    assert call[1][0] == (
+        "https://testdomain.my.salesforce.com/services/Soap/u/42.0"
+    )
+    assert "SOAPAction" in call[2]["headers"]
+    assert call[2]["headers"]["SOAPAction"] == "login"
 
-#     @responses.activate
-#     def test_custom_domain_success(self):
-#         """Test custom domain login"""
-#         login_args = {
-#             'password': 'password',
-#             'security_token': 'token',
-#             'domain': 'testdomain.my'
-#         }
-#         self._test_login_success(
-#             re.compile(r'^https://testdomain.my.salesforce.com/.*$'),
-#             login_args)
 
-#     @responses.activate
-#     def test_custom_session_success(self):
-#         """Test custom session"""
-#         responses.add(
-#             responses.POST,
-#             re.compile(r'^https://.*$'),
-#             body=tests.LOGIN_RESPONSE_SUCCESS,
-#             status=http.OK
-#         )
-#         session_state = {
-#             'used': False,
-#         }
+@pytest.mark.asyncio
+async def test_failure(mock_httpx_client):
+    """Test login for custom domain"""
+    _, mock_client, inner = mock_httpx_client
+    mock_response = (
+        '<?xml version="1.0" encoding="UTF-8"?><soapenv:Envelope '
+        'xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" '
+        'xmlns:sf="urn:fault.partner.soap.sforce.com" '
+        'xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">'
+        '<soapenv:Body><soapenv:Fault><faultcode>INVALID_LOGIN</faultcode>'
+        '<faultstring>INVALID_LOGIN: Invalid username, password, '
+        'security token; or user locked out.</faultstring><detail>'
+        '<sf:LoginFault xsi:type="sf:LoginFault"><sf:exceptionCode>'
+        'INVALID_LOGIN</sf:exceptionCode><sf:exceptionMessage>Invalid '
+        'username, password, security token; or user locked out.'
+        '</sf:exceptionMessage></sf:LoginFault></detail></soapenv:Fault>'
+        '</soapenv:Body></soapenv:Envelope>'
+    )
+    fail_result = httpx.Response(
+        500,
+        request=httpx.Request("POST", "login.my.salesforce.com"),
+        content=mock_response
+    )
+    inner(fail_result)
+    mock_client.custom_session_attrib = "X-1-2-3"
 
-#         # pylint: disable=missing-docstring,unused-argument
-#         def on_response(*args, **kwargs):
-#             session_state['used'] = True
+    with pytest.raises(SalesforceAuthenticationFailed):
+        await SalesforceLogin(
+            session=mock_client,
+            username='foo@bar.com',
+            password='password',
+            security_token='token',
+        )
+    assert len(mock_client.method_calls) == 1
+    call = mock_client.method_calls[0]
+    assert call[0] == "post"
+    assert call[1][0].startswith(SOAP_URL)
+    assert "SOAPAction" in call[2]["headers"]
+    assert call[2]["headers"]["SOAPAction"] == "login"
 
-#         session = requests.Session()
-#         session.hooks = {
-#             'response': on_response,
-#         }
-#         session_id, instance = SalesforceLogin(
-#             session=session,
-#             username='foo@bar.com',
-#             password='password',
-#             security_token='token')
-#         self.assertTrue(session_state['used'])
-#         self.assertEqual(session_id, tests.SESSION_ID)
-#         self.assertEqual(instance, urlparse(tests.SERVER_URL).netloc)
 
-#     def test_failure(self):
-#         """Test A Failed Login Response"""
-#         return_mock = Mock()
-#         return_mock.status_code = 500
-#         # pylint: disable=line-too-long
-#         return_mock.content = '<?xml version="1.0" encoding="UTF-8"?><soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:sf="urn:fault.partner.soap.sforce.com" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><soapenv:Body><soapenv:Fault><faultcode>INVALID_LOGIN</faultcode><faultstring>INVALID_LOGIN: Invalid username, password, security token; or user locked out.</faultstring><detail><sf:LoginFault xsi:type="sf:LoginFault"><sf:exceptionCode>INVALID_LOGIN</sf:exceptionCode><sf:exceptionMessage>Invalid username, password, security token; or user locked out.</sf:exceptionMessage></sf:LoginFault></detail></soapenv:Fault></soapenv:Body></soapenv:Envelope>'
-#         self.mockrequest.post.return_value = return_mock
+@pytest.fixture()
+def sample_key_filepath():
+    """Path to sample-key fixture"""
+    return os.path.join(PARENT_DIR, "sample-key.pem")
 
-#         with self.assertRaises(SalesforceAuthenticationFailed):
-#             SalesforceLogin(
-#                 username='myemail@example.com.sandbox',
-#                 password='password',
-#                 security_token='token',
-#                 domain='test'
-#             )
-#         self.assertTrue(self.mockrequest.post.called)
 
-#     @responses.activate
-#     def test_token_login_success_with_key_file(self):
-#         """Test a successful JWT Token login with a key file"""
-#         pkey_file = os.path.join(os.path.dirname(__file__), 'sample-key.pem')
-#         login_args = {
-#             'consumer_key': '12345.abcde',
-#             'privatekey_file': pkey_file
-#         }
-#         self._test_login_success(
-#             re.compile(r'^https://login.salesforce.com/.*$'), login_args,
-#             response_body=tests.TOKEN_LOGIN_RESPONSE_SUCCESS)
+@pytest.fixture()
+def sample_key(sample_key_filepath):
+    """File-handle in bytes for sample-key fixture"""
+    with open(sample_key_filepath, 'rb') as key_file:
+        return key_file.read()
 
-#     @responses.activate
-#     def test_token_login_success_with_key(self):
-#         """Test a successful JWT Token login with a key from a string"""
-#         pkey_file = os.path.join(os.path.dirname(__file__), 'sample-key.pem')
-#         with open(pkey_file, 'rb') as key_file:
-#             key = key_file.read().decode("utf-8")
 
-#         login_args = {
-#             'consumer_key': '12345.abcde',
-#             'privatekey': key
-#         }
-#         self._test_login_success(
-#             re.compile(r'^https://login.salesforce.com/.*$'), login_args,
-#             response_body=tests.TOKEN_LOGIN_RESPONSE_SUCCESS)
+@pytest.mark.asyncio
+async def test_token_login_success_with_key_file(sample_key_filepath, constants, mock_httpx_client):
+    """Test a successful JWT Token login with a key file"""
+    _, mock_client, inner = mock_httpx_client
+    happy_result = httpx.Response(
+        200,
+        content=constants["TOKEN_LOGIN_RESPONSE_SUCCESS"]
+    )
+    inner(happy_result)
 
-#     @responses.activate
-#     def test_token_login_success_with_key_bytes(self):
-#         """Test a successful JWT Token login with key bytes"""
-#         pkey_file = os.path.join(os.path.dirname(__file__), 'sample-key.pem')
-#         with open(pkey_file, 'rb') as key:
-#             key_bytes = key.read()
+    (session_id, instance_url) = await SalesforceLogin(
+        session=mock_client,
+        username='foo@bar.com',
+        consumer_key='12345.abcde',
+        privatekey_file=sample_key_filepath
+    )
+    assert session_id == constants["SESSION_ID"]
+    assert instance_url == urlparse(constants["INSTANCE_URL"]).netloc
+    assert len(mock_client.method_calls) == 1
+    call = mock_client.method_calls[0]
+    assert call[0] == "post"
+    assert call[1][0].startswith(OAUTH_TOKEN_URL)
+    assert call[2]["data"]["grant_type"] == (
+        "urn:ietf:params:oauth:grant-type:jwt-bearer"
+    )
 
-#         login_args = {
-#             'consumer_key': '12345.abcde',
-#             'privatekey': key_bytes
-#         }
-#         self._test_login_success(
-#             re.compile(r'^https://login.salesforce.com/.*$'), login_args,
-#             response_body=tests.TOKEN_LOGIN_RESPONSE_SUCCESS)
+@pytest.mark.asyncio
+async def test_token_login_success_with_key_string(
+    sample_key, constants, mock_httpx_client
+):
+    """Test a successful JWT Token login with a private key"""
+    _, mock_client, inner = mock_httpx_client
+    happy_result = httpx.Response(
+        200,
+        content=constants["TOKEN_LOGIN_RESPONSE_SUCCESS"]
+    )
+    inner(happy_result)
+    (session_id, instance_url) = await SalesforceLogin(
+        session=mock_client,
+        username='foo@bar.com',
+        consumer_key='12345.abcde',
+        privatekey=sample_key.decode()
+    )
 
-#     def test_token_login_failure(self):
-#         """Test a failed JWT Token login"""
-#         return_mock = Mock()
-#         return_mock.status_code = 400
-#         # pylint: disable=line-too-long
-#         return_mock.content = '{"error": "invalid_client_id", "error_description": "client identifier invalid"}'
-#         self.mockrequest.post.return_value = return_mock
+    assert session_id == constants["SESSION_ID"]
+    assert instance_url == urlparse(constants["INSTANCE_URL"]).netloc
+    assert len(mock_client.method_calls) == 1
+    call = mock_client.method_calls[0]
+    assert call[0] == "post"
+    assert call[1][0].startswith(OAUTH_TOKEN_URL)
+    assert call[2]["data"]["grant_type"] == (
+        "urn:ietf:params:oauth:grant-type:jwt-bearer"
+    )
 
-#         with self.assertRaises(SalesforceAuthenticationFailed):
-#             SalesforceLogin(
-#                 username='myemail@example.com.sandbox',
-#                 consumer_key='12345.abcde',
-#                 privatekey_file=os.path.join(
-#                     os.path.dirname(__file__), 'sample-key.pem'
-#                 )
-#             )
-#         self.assertTrue(self.mockrequest.post.called)
 
-#     @responses.activate
-#     def test_token_login_failure_with_warning(self):
-#         """Test a failed JWT Token login that also produces a helful warning"""
-#         responses.add(
-#             responses.POST,
-#             re.compile(r'^https://login.*$'),
-#             # pylint: disable=line-too-long
-#             body='{"error": "invalid_grant", "error_description": "user hasn\'t approved this consumer"}',
-#             status=400
-#         )
-#         session_state = {
-#             'used': False,
-#         }
+@pytest.mark.asyncio
+async def test_token_login_success_with_key_bytes(
+    sample_key, constants, mock_httpx_client
+):
+    """Test a successful JWT Token login with a private key"""
+    _, mock_client, inner = mock_httpx_client
+    happy_result = httpx.Response(
+        200,
+        content=constants["TOKEN_LOGIN_RESPONSE_SUCCESS"]
+    )
+    inner(happy_result)
+    (session_id, instance_url) = await SalesforceLogin(
+        session=mock_client,
+        username='foo@bar.com',
+        consumer_key='12345.abcde',
+        privatekey=sample_key
+    )
 
-#         # pylint: disable=missing-docstring,unused-argument
-#         def on_response(*args, **kwargs):
-#             session_state['used'] = True
+    assert session_id == constants["SESSION_ID"]
+    assert instance_url == urlparse(constants["INSTANCE_URL"]).netloc
+    assert len(mock_client.method_calls) == 1
+    call = mock_client.method_calls[0]
+    assert call[0] == "post"
+    assert call[1][0].startswith(OAUTH_TOKEN_URL)
+    assert call[2]["data"]["grant_type"] == (
+        "urn:ietf:params:oauth:grant-type:jwt-bearer"
+    )
 
-#         session = requests.Session()
-#         session.hooks = {
-#             'response': on_response,
-#         }
-#         with warnings.catch_warnings(record=True) as warning:
-#             with self.assertRaises(SalesforceAuthenticationFailed):
-#                 # pylint: disable=unused-variable
-#                 session_id, instance = SalesforceLogin(
-#                     session=session,
-#                     username='foo@bar.com',
-#                     consumer_key='12345.abcde',
-#                     privatekey_file=os.path.join(
-#                         os.path.dirname(__file__), 'sample-key.pem'
-#                     )
-#                 )
-#             assert len(warning) >= 1
-#             assert issubclass(warning[-1].category, UserWarning)
-#             assert str(warning[-1].message) == tests.TOKEN_WARNING
-#         self.assertTrue(session_state['used'])
+
+@pytest.mark.asyncio
+async def test_token_login_failure(mock_httpx_client, sample_key_filepath):
+    """Test login for custom domain"""
+    _, mock_client, inner = mock_httpx_client
+    fail_result = httpx.Response(
+        400,
+        request=httpx.Request("POST", "login.my.salesforce.com"),
+        content=json.dumps({
+            "error": "invalid_client_id",
+            "error_description":
+            "client identifier invalid"
+        })
+    )
+    inner(fail_result)
+
+    with pytest.raises(SalesforceAuthenticationFailed):
+        await SalesforceLogin(
+            session=mock_client,
+            username='foo@bar.com',
+            consumer_key='12345.abcde',
+            privatekey_file=sample_key_filepath
+        )
+    assert len(mock_client.method_calls) == 1
+    call = mock_client.method_calls[0]
+
+    assert call[0] == "post"
+    assert call[1][0].startswith(OAUTH_TOKEN_URL)
+    assert call[2]["data"]["grant_type"] == (
+        "urn:ietf:params:oauth:grant-type:jwt-bearer"
+    )
+
+
+@pytest.mark.asyncio
+async def test_token_login_failure_with_warning(mock_httpx_client, constants, sample_key_filepath):
+    """Test login for custom domain"""
+    _, mock_client, inner = mock_httpx_client
+    fail_result = httpx.Response(
+        400,
+        request=httpx.Request("POST", "login.my.salesforce.com"),
+        content=json.dumps({
+            "error": "invalid_grant",
+            "error_description":
+            "user hasn't approved this consumer"
+        })
+    )
+    inner(fail_result)
+    with warnings.catch_warnings(record=True) as warning:
+        with pytest.raises(SalesforceAuthenticationFailed):
+            await SalesforceLogin(
+                session=mock_client,
+                username='foo@bar.com',
+                consumer_key='12345.abcde',
+                privatekey_file=sample_key_filepath
+            )
+    assert len(mock_client.method_calls) == 1
+    call = mock_client.method_calls[0]
+
+    assert call[0] == "post"
+    assert call[1][0].startswith(OAUTH_TOKEN_URL)
+    assert call[2]["data"]["grant_type"] == (
+        "urn:ietf:params:oauth:grant-type:jwt-bearer"
+    )
+    assert len(warning) >= 1
+    assert issubclass(warning[-1].category, UserWarning)
+    assert str(warning[-1].message) == constants["TOKEN_WARNING"]

--- a/simple_salesforce/tests/test_aio/test_login.py
+++ b/simple_salesforce/tests/test_aio/test_login.py
@@ -1,0 +1,224 @@
+"""Tests for login.py"""
+
+import http.client as http
+import os
+import re
+import unittest
+import warnings
+from unittest.mock import Mock, patch
+from urllib.parse import urlparse
+
+import requests
+import responses
+from simple_salesforce import tests
+from simple_salesforce.exceptions import SalesforceAuthenticationFailed
+from simple_salesforce.login import SalesforceLogin
+
+
+# class TestSalesforceLogin(unittest.TestCase):
+#     """Tests for the SalesforceLogin function"""
+
+#     def setUp(self):
+#         """Setup the SalesforceLogin tests"""
+#         request_patcher = patch('simple_salesforce.login.requests')
+#         self.mockrequest = request_patcher.start()
+#         self.addCleanup(request_patcher.stop)
+
+#     def _test_login_success(self, url_regex, salesforce_login_kwargs,
+#                             response_body=tests.LOGIN_RESPONSE_SUCCESS):
+#         """Test SalesforceLogin with one set of arguments.
+
+#         Mock login requests at url_regex, returning a successful response,
+#         response_body. Check that the fake-login process works when passing
+#         salesforce_login_kwargs as keyword arguments to SalesforceLogin in
+#         addition to the mocked session and a default username.
+#         """
+#         responses.add(
+#             responses.POST,
+#             url_regex,
+#             body=response_body,
+#             status=http.OK
+#         )
+#         session_state = {
+#             'used': False,
+#         }
+
+#         # pylint: disable=missing-docstring,unused-argument
+#         def on_response(*args, **kwargs):
+#             session_state['used'] = True
+
+#         session = requests.Session()
+#         session.hooks = {
+#             'response': on_response,
+#         }
+#         session_id, instance = SalesforceLogin(
+#             session=session,
+#             username='foo@bar.com',
+#             **salesforce_login_kwargs
+#         )
+#         self.assertTrue(session_state['used'])
+#         self.assertEqual(session_id, tests.SESSION_ID)
+#         self.assertEqual(instance, urlparse(tests.SERVER_URL).netloc)
+
+#     @responses.activate
+#     def test_default_domain_success(self):
+#         """Test default domain logic and login"""
+#         login_args = {'password': 'password', 'security_token': 'token'}
+#         self._test_login_success(re.compile(r'^https://login.*$'), login_args)
+
+#     @responses.activate
+#     def test_custom_domain_success(self):
+#         """Test custom domain login"""
+#         login_args = {
+#             'password': 'password',
+#             'security_token': 'token',
+#             'domain': 'testdomain.my'
+#         }
+#         self._test_login_success(
+#             re.compile(r'^https://testdomain.my.salesforce.com/.*$'),
+#             login_args)
+
+#     @responses.activate
+#     def test_custom_session_success(self):
+#         """Test custom session"""
+#         responses.add(
+#             responses.POST,
+#             re.compile(r'^https://.*$'),
+#             body=tests.LOGIN_RESPONSE_SUCCESS,
+#             status=http.OK
+#         )
+#         session_state = {
+#             'used': False,
+#         }
+
+#         # pylint: disable=missing-docstring,unused-argument
+#         def on_response(*args, **kwargs):
+#             session_state['used'] = True
+
+#         session = requests.Session()
+#         session.hooks = {
+#             'response': on_response,
+#         }
+#         session_id, instance = SalesforceLogin(
+#             session=session,
+#             username='foo@bar.com',
+#             password='password',
+#             security_token='token')
+#         self.assertTrue(session_state['used'])
+#         self.assertEqual(session_id, tests.SESSION_ID)
+#         self.assertEqual(instance, urlparse(tests.SERVER_URL).netloc)
+
+#     def test_failure(self):
+#         """Test A Failed Login Response"""
+#         return_mock = Mock()
+#         return_mock.status_code = 500
+#         # pylint: disable=line-too-long
+#         return_mock.content = '<?xml version="1.0" encoding="UTF-8"?><soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:sf="urn:fault.partner.soap.sforce.com" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><soapenv:Body><soapenv:Fault><faultcode>INVALID_LOGIN</faultcode><faultstring>INVALID_LOGIN: Invalid username, password, security token; or user locked out.</faultstring><detail><sf:LoginFault xsi:type="sf:LoginFault"><sf:exceptionCode>INVALID_LOGIN</sf:exceptionCode><sf:exceptionMessage>Invalid username, password, security token; or user locked out.</sf:exceptionMessage></sf:LoginFault></detail></soapenv:Fault></soapenv:Body></soapenv:Envelope>'
+#         self.mockrequest.post.return_value = return_mock
+
+#         with self.assertRaises(SalesforceAuthenticationFailed):
+#             SalesforceLogin(
+#                 username='myemail@example.com.sandbox',
+#                 password='password',
+#                 security_token='token',
+#                 domain='test'
+#             )
+#         self.assertTrue(self.mockrequest.post.called)
+
+#     @responses.activate
+#     def test_token_login_success_with_key_file(self):
+#         """Test a successful JWT Token login with a key file"""
+#         pkey_file = os.path.join(os.path.dirname(__file__), 'sample-key.pem')
+#         login_args = {
+#             'consumer_key': '12345.abcde',
+#             'privatekey_file': pkey_file
+#         }
+#         self._test_login_success(
+#             re.compile(r'^https://login.salesforce.com/.*$'), login_args,
+#             response_body=tests.TOKEN_LOGIN_RESPONSE_SUCCESS)
+
+#     @responses.activate
+#     def test_token_login_success_with_key(self):
+#         """Test a successful JWT Token login with a key from a string"""
+#         pkey_file = os.path.join(os.path.dirname(__file__), 'sample-key.pem')
+#         with open(pkey_file, 'rb') as key_file:
+#             key = key_file.read().decode("utf-8")
+
+#         login_args = {
+#             'consumer_key': '12345.abcde',
+#             'privatekey': key
+#         }
+#         self._test_login_success(
+#             re.compile(r'^https://login.salesforce.com/.*$'), login_args,
+#             response_body=tests.TOKEN_LOGIN_RESPONSE_SUCCESS)
+
+#     @responses.activate
+#     def test_token_login_success_with_key_bytes(self):
+#         """Test a successful JWT Token login with key bytes"""
+#         pkey_file = os.path.join(os.path.dirname(__file__), 'sample-key.pem')
+#         with open(pkey_file, 'rb') as key:
+#             key_bytes = key.read()
+
+#         login_args = {
+#             'consumer_key': '12345.abcde',
+#             'privatekey': key_bytes
+#         }
+#         self._test_login_success(
+#             re.compile(r'^https://login.salesforce.com/.*$'), login_args,
+#             response_body=tests.TOKEN_LOGIN_RESPONSE_SUCCESS)
+
+#     def test_token_login_failure(self):
+#         """Test a failed JWT Token login"""
+#         return_mock = Mock()
+#         return_mock.status_code = 400
+#         # pylint: disable=line-too-long
+#         return_mock.content = '{"error": "invalid_client_id", "error_description": "client identifier invalid"}'
+#         self.mockrequest.post.return_value = return_mock
+
+#         with self.assertRaises(SalesforceAuthenticationFailed):
+#             SalesforceLogin(
+#                 username='myemail@example.com.sandbox',
+#                 consumer_key='12345.abcde',
+#                 privatekey_file=os.path.join(
+#                     os.path.dirname(__file__), 'sample-key.pem'
+#                 )
+#             )
+#         self.assertTrue(self.mockrequest.post.called)
+
+#     @responses.activate
+#     def test_token_login_failure_with_warning(self):
+#         """Test a failed JWT Token login that also produces a helful warning"""
+#         responses.add(
+#             responses.POST,
+#             re.compile(r'^https://login.*$'),
+#             # pylint: disable=line-too-long
+#             body='{"error": "invalid_grant", "error_description": "user hasn\'t approved this consumer"}',
+#             status=400
+#         )
+#         session_state = {
+#             'used': False,
+#         }
+
+#         # pylint: disable=missing-docstring,unused-argument
+#         def on_response(*args, **kwargs):
+#             session_state['used'] = True
+
+#         session = requests.Session()
+#         session.hooks = {
+#             'response': on_response,
+#         }
+#         with warnings.catch_warnings(record=True) as warning:
+#             with self.assertRaises(SalesforceAuthenticationFailed):
+#                 # pylint: disable=unused-variable
+#                 session_id, instance = SalesforceLogin(
+#                     session=session,
+#                     username='foo@bar.com',
+#                     consumer_key='12345.abcde',
+#                     privatekey_file=os.path.join(
+#                         os.path.dirname(__file__), 'sample-key.pem'
+#                     )
+#                 )
+#             assert len(warning) >= 1
+#             assert issubclass(warning[-1].category, UserWarning)
+#             assert str(warning[-1].message) == tests.TOKEN_WARNING
+#         self.assertTrue(session_state['used'])

--- a/simple_salesforce/tests/test_aio/test_login.py
+++ b/simple_salesforce/tests/test_aio/test_login.py
@@ -20,18 +20,15 @@ OAUTH_TOKEN_URL = "https://login.salesforce.com/services/oauth2/token"
 async def test_default_domain_success(constants, mock_httpx_client):
     """Test login for default domain"""
     _, mock_client, inner = mock_httpx_client
-    happy_result = httpx.Response(
-        200,
-        content=constants["LOGIN_RESPONSE_SUCCESS"]
-    )
+    happy_result = httpx.Response(200, content=constants["LOGIN_RESPONSE_SUCCESS"])
     inner(happy_result)
     mock_client.custom_session_attrib = "X-1-2-3"
 
     (session_id, instance_url) = await AsyncSalesforceLogin(
         session=mock_client,
-        username='foo@bar.com',
-        password='password',
-        security_token='token'
+        username="foo@bar.com",
+        password="password",
+        security_token="token",
     )
     assert session_id == constants["SESSION_ID"]
     assert instance_url == urlparse(constants["INSTANCE_URL"]).netloc
@@ -47,27 +44,22 @@ async def test_default_domain_success(constants, mock_httpx_client):
 async def test_custom_domain_success(constants, mock_httpx_client):
     """Test login for custom domain"""
     _, mock_client, inner = mock_httpx_client
-    happy_result = httpx.Response(
-        200,
-        content=constants["LOGIN_RESPONSE_SUCCESS"]
-    )
+    happy_result = httpx.Response(200, content=constants["LOGIN_RESPONSE_SUCCESS"])
     inner(happy_result)
     mock_client.custom_session_attrib = "X-1-2-3"
 
     (session_id, instance_url) = await AsyncSalesforceLogin(
         session=mock_client,
-        username='foo@bar.com',
-        password='password',
-        domain='testdomain.my'
+        username="foo@bar.com",
+        password="password",
+        domain="testdomain.my",
     )
     assert session_id == constants["SESSION_ID"]
     assert instance_url == urlparse(constants["INSTANCE_URL"]).netloc
     assert len(mock_client.method_calls) == 1
     call = mock_client.method_calls[0]
     assert call[0] == "post"
-    assert call[1][0] == (
-        "https://testdomain.my.salesforce.com/services/Soap/u/42.0"
-    )
+    assert call[1][0] == ("https://testdomain.my.salesforce.com/services/Soap/u/42.0")
     assert "SOAPAction" in call[2]["headers"]
     assert call[2]["headers"]["SOAPAction"] == "login"
 
@@ -81,19 +73,19 @@ async def test_failure(mock_httpx_client):
         'xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" '
         'xmlns:sf="urn:fault.partner.soap.sforce.com" '
         'xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">'
-        '<soapenv:Body><soapenv:Fault><faultcode>INVALID_LOGIN</faultcode>'
-        '<faultstring>INVALID_LOGIN: Invalid username, password, '
-        'security token; or user locked out.</faultstring><detail>'
+        "<soapenv:Body><soapenv:Fault><faultcode>INVALID_LOGIN</faultcode>"
+        "<faultstring>INVALID_LOGIN: Invalid username, password, "
+        "security token; or user locked out.</faultstring><detail>"
         '<sf:LoginFault xsi:type="sf:LoginFault"><sf:exceptionCode>'
-        'INVALID_LOGIN</sf:exceptionCode><sf:exceptionMessage>Invalid '
-        'username, password, security token; or user locked out.'
-        '</sf:exceptionMessage></sf:LoginFault></detail></soapenv:Fault>'
-        '</soapenv:Body></soapenv:Envelope>'
+        "INVALID_LOGIN</sf:exceptionCode><sf:exceptionMessage>Invalid "
+        "username, password, security token; or user locked out."
+        "</sf:exceptionMessage></sf:LoginFault></detail></soapenv:Fault>"
+        "</soapenv:Body></soapenv:Envelope>"
     )
     fail_result = httpx.Response(
         500,
         request=httpx.Request("POST", "login.my.salesforce.com"),
-        content=mock_response
+        content=mock_response,
     )
     inner(fail_result)
     mock_client.custom_session_attrib = "X-1-2-3"
@@ -101,9 +93,9 @@ async def test_failure(mock_httpx_client):
     with pytest.raises(SalesforceAuthenticationFailed):
         await AsyncSalesforceLogin(
             session=mock_client,
-            username='foo@bar.com',
-            password='password',
-            security_token='token',
+            username="foo@bar.com",
+            password="password",
+            security_token="token",
         )
     assert len(mock_client.method_calls) == 1
     call = mock_client.method_calls[0]
@@ -122,25 +114,26 @@ def sample_key_filepath():
 @pytest.fixture()
 def sample_key(sample_key_filepath):
     """File-handle in bytes for sample-key fixture"""
-    with open(sample_key_filepath, 'rb') as key_file:
+    with open(sample_key_filepath, "rb") as key_file:
         return key_file.read()
 
 
 @pytest.mark.asyncio
-async def test_token_login_success_with_key_file(sample_key_filepath, constants, mock_httpx_client):
+async def test_token_login_success_with_key_file(
+    sample_key_filepath, constants, mock_httpx_client
+):
     """Test a successful JWT Token login with a key file"""
     _, mock_client, inner = mock_httpx_client
     happy_result = httpx.Response(
-        200,
-        content=constants["TOKEN_LOGIN_RESPONSE_SUCCESS"]
+        200, content=constants["TOKEN_LOGIN_RESPONSE_SUCCESS"]
     )
     inner(happy_result)
 
     (session_id, instance_url) = await AsyncSalesforceLogin(
         session=mock_client,
-        username='foo@bar.com',
-        consumer_key='12345.abcde',
-        privatekey_file=sample_key_filepath
+        username="foo@bar.com",
+        consumer_key="12345.abcde",
+        privatekey_file=sample_key_filepath,
     )
     assert session_id == constants["SESSION_ID"]
     assert instance_url == urlparse(constants["INSTANCE_URL"]).netloc
@@ -152,6 +145,7 @@ async def test_token_login_success_with_key_file(sample_key_filepath, constants,
         "urn:ietf:params:oauth:grant-type:jwt-bearer"
     )
 
+
 @pytest.mark.asyncio
 async def test_token_login_success_with_key_string(
     sample_key, constants, mock_httpx_client
@@ -159,15 +153,14 @@ async def test_token_login_success_with_key_string(
     """Test a successful JWT Token login with a private key"""
     _, mock_client, inner = mock_httpx_client
     happy_result = httpx.Response(
-        200,
-        content=constants["TOKEN_LOGIN_RESPONSE_SUCCESS"]
+        200, content=constants["TOKEN_LOGIN_RESPONSE_SUCCESS"]
     )
     inner(happy_result)
     (session_id, instance_url) = await AsyncSalesforceLogin(
         session=mock_client,
-        username='foo@bar.com',
-        consumer_key='12345.abcde',
-        privatekey=sample_key.decode()
+        username="foo@bar.com",
+        consumer_key="12345.abcde",
+        privatekey=sample_key.decode(),
     )
 
     assert session_id == constants["SESSION_ID"]
@@ -188,15 +181,14 @@ async def test_token_login_success_with_key_bytes(
     """Test a successful JWT Token login with a private key"""
     _, mock_client, inner = mock_httpx_client
     happy_result = httpx.Response(
-        200,
-        content=constants["TOKEN_LOGIN_RESPONSE_SUCCESS"]
+        200, content=constants["TOKEN_LOGIN_RESPONSE_SUCCESS"]
     )
     inner(happy_result)
     (session_id, instance_url) = await AsyncSalesforceLogin(
         session=mock_client,
-        username='foo@bar.com',
-        consumer_key='12345.abcde',
-        privatekey=sample_key
+        username="foo@bar.com",
+        consumer_key="12345.abcde",
+        privatekey=sample_key,
     )
 
     assert session_id == constants["SESSION_ID"]
@@ -217,20 +209,21 @@ async def test_token_login_failure(mock_httpx_client, sample_key_filepath):
     fail_result = httpx.Response(
         400,
         request=httpx.Request("POST", "login.my.salesforce.com"),
-        content=json.dumps({
-            "error": "invalid_client_id",
-            "error_description":
-            "client identifier invalid"
-        })
+        content=json.dumps(
+            {
+                "error": "invalid_client_id",
+                "error_description": "client identifier invalid",
+            }
+        ),
     )
     inner(fail_result)
 
     with pytest.raises(SalesforceAuthenticationFailed):
         await AsyncSalesforceLogin(
             session=mock_client,
-            username='foo@bar.com',
-            consumer_key='12345.abcde',
-            privatekey_file=sample_key_filepath
+            username="foo@bar.com",
+            consumer_key="12345.abcde",
+            privatekey_file=sample_key_filepath,
         )
     assert len(mock_client.method_calls) == 1
     call = mock_client.method_calls[0]
@@ -243,26 +236,29 @@ async def test_token_login_failure(mock_httpx_client, sample_key_filepath):
 
 
 @pytest.mark.asyncio
-async def test_token_login_failure_with_warning(mock_httpx_client, constants, sample_key_filepath):
+async def test_token_login_failure_with_warning(
+    mock_httpx_client, constants, sample_key_filepath
+):
     """Test login for custom domain"""
     _, mock_client, inner = mock_httpx_client
     fail_result = httpx.Response(
         400,
         request=httpx.Request("POST", "login.my.salesforce.com"),
-        content=json.dumps({
-            "error": "invalid_grant",
-            "error_description":
-            "user hasn't approved this consumer"
-        })
+        content=json.dumps(
+            {
+                "error": "invalid_grant",
+                "error_description": "user hasn't approved this consumer",
+            }
+        ),
     )
     inner(fail_result)
     with warnings.catch_warnings(record=True) as warning:
         with pytest.raises(SalesforceAuthenticationFailed):
             await AsyncSalesforceLogin(
                 session=mock_client,
-                username='foo@bar.com',
-                consumer_key='12345.abcde',
-                privatekey_file=sample_key_filepath
+                username="foo@bar.com",
+                consumer_key="12345.abcde",
+                privatekey_file=sample_key_filepath,
             )
     assert len(mock_client.method_calls) == 1
     call = mock_client.method_calls[0]

--- a/simple_salesforce/tests/test_aio/test_login.py
+++ b/simple_salesforce/tests/test_aio/test_login.py
@@ -8,7 +8,7 @@ import httpx
 import pytest
 
 from simple_salesforce.exceptions import SalesforceAuthenticationFailed
-from simple_salesforce.aio.login import SalesforceLogin
+from simple_salesforce.aio.login import AsyncSalesforceLogin
 
 
 PARENT_DIR = os.path.dirname(os.path.dirname(__file__))
@@ -27,7 +27,7 @@ async def test_default_domain_success(constants, mock_httpx_client):
     inner(happy_result)
     mock_client.custom_session_attrib = "X-1-2-3"
 
-    (session_id, instance_url) = await SalesforceLogin(
+    (session_id, instance_url) = await AsyncSalesforceLogin(
         session=mock_client,
         username='foo@bar.com',
         password='password',
@@ -54,11 +54,10 @@ async def test_custom_domain_success(constants, mock_httpx_client):
     inner(happy_result)
     mock_client.custom_session_attrib = "X-1-2-3"
 
-    (session_id, instance_url) = await SalesforceLogin(
+    (session_id, instance_url) = await AsyncSalesforceLogin(
         session=mock_client,
         username='foo@bar.com',
         password='password',
-        security_token='token',
         domain='testdomain.my'
     )
     assert session_id == constants["SESSION_ID"]
@@ -100,7 +99,7 @@ async def test_failure(mock_httpx_client):
     mock_client.custom_session_attrib = "X-1-2-3"
 
     with pytest.raises(SalesforceAuthenticationFailed):
-        await SalesforceLogin(
+        await AsyncSalesforceLogin(
             session=mock_client,
             username='foo@bar.com',
             password='password',
@@ -137,7 +136,7 @@ async def test_token_login_success_with_key_file(sample_key_filepath, constants,
     )
     inner(happy_result)
 
-    (session_id, instance_url) = await SalesforceLogin(
+    (session_id, instance_url) = await AsyncSalesforceLogin(
         session=mock_client,
         username='foo@bar.com',
         consumer_key='12345.abcde',
@@ -164,7 +163,7 @@ async def test_token_login_success_with_key_string(
         content=constants["TOKEN_LOGIN_RESPONSE_SUCCESS"]
     )
     inner(happy_result)
-    (session_id, instance_url) = await SalesforceLogin(
+    (session_id, instance_url) = await AsyncSalesforceLogin(
         session=mock_client,
         username='foo@bar.com',
         consumer_key='12345.abcde',
@@ -193,7 +192,7 @@ async def test_token_login_success_with_key_bytes(
         content=constants["TOKEN_LOGIN_RESPONSE_SUCCESS"]
     )
     inner(happy_result)
-    (session_id, instance_url) = await SalesforceLogin(
+    (session_id, instance_url) = await AsyncSalesforceLogin(
         session=mock_client,
         username='foo@bar.com',
         consumer_key='12345.abcde',
@@ -227,7 +226,7 @@ async def test_token_login_failure(mock_httpx_client, sample_key_filepath):
     inner(fail_result)
 
     with pytest.raises(SalesforceAuthenticationFailed):
-        await SalesforceLogin(
+        await AsyncSalesforceLogin(
             session=mock_client,
             username='foo@bar.com',
             consumer_key='12345.abcde',
@@ -259,7 +258,7 @@ async def test_token_login_failure_with_warning(mock_httpx_client, constants, sa
     inner(fail_result)
     with warnings.catch_warnings(record=True) as warning:
         with pytest.raises(SalesforceAuthenticationFailed):
-            await SalesforceLogin(
+            await AsyncSalesforceLogin(
                 session=mock_client,
                 username='foo@bar.com',
                 consumer_key='12345.abcde',

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,2 +1,5 @@
 pylint
 coverage
+pytest
+pytest-asyncio
+pytest-coverage


### PR DESCRIPTION
This PR creates a new package `aio` inside the `simple_salesforce` parent. Inside `aio` all HTTP calls are replaced for `async` equivalents. In addition, tests from the parent package for relevant modules have been copied in here. Currently, the following test coverage is present for these:

```sh
---------- coverage: platform darwin, python 3.9.6-final-0 -----------
Name                                Stmts   Miss  Cover
-------------------------------------------------------
simple_salesforce/aio/__init__.py       3      0   100%
simple_salesforce/aio/aio_util.py      14      0   100%
simple_salesforce/aio/api.py          276     80    71%
simple_salesforce/aio/bulk.py         132      8    94%
simple_salesforce/aio/login.py         83     13    84%
simple_salesforce/aio/metadata.py     155     68    56%
-------------------------------------------------------
TOTAL                                 663    169    75%
Coverage HTML written to dir htmlcov
```

## Details

- Adds `aio` package with Async http calls based on `httpx`
- Async generators swapped out for equivalent generators
- `aiofiles` used for file-opening
- Tests copied from the parent for each relevant module added and reimplemented for async
- `setup.py` given a new `extras_require` section in order to install `simple-salesforce` with async support and includes the following deps: `'httpx>=0.18.2,<1.0', 'aiofiles>=0.7.0'`
- 

## Notes

- Tests added here make heavy use of `pytest`, which is not currently a dependency for `simple-salesforce` development.
- Proxy logic has been included but is untested.
- Basic functionality has been verified, but this is an alpha stage right now.

## To Do

- Add more tests for `metadata` module.
- More testing for the API here including for proxies and bulk.