### PR TITLE
Remove Context Manager use around Async Client

### DIFF
--- a/simple_salesforce/__version__.py
+++ b/simple_salesforce/__version__.py
@@ -5,7 +5,7 @@ This file shamelessly taken from the requests library"""
 __title__ = 'simple-salesforce'
 __description__ = 'A basic Salesforce.com REST API client.'
 __url__ = 'https://github.com/simple-salesforce/simple-salesforce'
-__version__ = '1.12.1a1'
+__version__ = '1.12.1a2'
 __author__ = 'Nick Catalano'
 __author_email__ = 'nickcatal@gmail.com'
 __license__ = 'Apache 2.0'

--- a/simple_salesforce/aio/aio_util.py
+++ b/simple_salesforce/aio/aio_util.py
@@ -23,9 +23,10 @@ async def call_salesforce(
     headers = headers or dict()
     additional_headers = kwargs.pop('additional_headers', dict())
     headers.update(additional_headers or dict())
-    async with async_client as client:
-        result = await client.request(method, url, headers=headers, **kwargs)
+    result = await async_client.request(method, url, headers=headers, **kwargs)
     if result.status_code >= 300:
         exception_handler(result)
+    if not async_client:
+        await async_client.aclose()
 
     return result

--- a/simple_salesforce/aio/api.py
+++ b/simple_salesforce/aio/api.py
@@ -182,12 +182,12 @@ class SessionMixin:
         Offer users a method to _close_ a session.
         """
         if (
-            hasattr(self._session)
+            getattr(self, "_session")
             and self._session
             and hasattr(self._session, "aclose")
         ):
             await self._session.aclose()
-            self.session = None
+            self._session = None
 
     @property
     def session(self):

--- a/simple_salesforce/aio/login.py
+++ b/simple_salesforce/aio/login.py
@@ -214,10 +214,11 @@ async def soap_login(soap_url, request_body, headers, proxies, session=None):
     else:
         client = httpx.AsyncClient()
 
-    async with client:
-        response = await client.post(
-            soap_url, data=request_body, headers=headers
-        )
+    response = await client.post(
+        soap_url, data=request_body, headers=headers
+    )
+    if not session:
+        await client.aclose()
 
     if response.status_code != 200:
         except_code = getUniqueElementValueFromXmlString(
@@ -251,10 +252,11 @@ async def token_login(
     else:
         client = httpx.AsyncClient()
 
-    async with client:
-        response = await client.post(
-            token_url, data=token_data, headers=headers
-        )
+    response = await client.post(
+        token_url, data=token_data, headers=headers
+    )
+    if not session:
+        await client.aclose()
 
     try:
         json_response = response.json()


### PR DESCRIPTION
We had a problem with developers on Windows seeing issues with closed clients getting reused. It does seem like an issue that should affect everyone but so far it has not. At any rate, this PR strips away the context manager stuff and creates a session and then uses it. The trick is that users will likely need to know that they should call `aclose` at some point. However, the goal has been to try to stay consistent with the API offered by upstream: if a session has been passed in, we'd like to use it.