### PR TITLE
Latest Upstream Changes Adapted to aio package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,11 +31,10 @@ setup(
     install_requires = [
         'requests>=2.22.0',
         'authlib',
-        'zeep'
+        'zeep',
+        'httpx>=0.20.0,<1.0',
+        'aiofiles>=0.7.0'
     ],
-    extras_require={
-        "async": ['httpx>=0.20.0,<1.0', 'aiofiles>=0.7.0']
-    },
                    tests_require = [
                                        'nose>=1.3.0',
                                        'pytz>=2014.1.1',

--- a/simple_salesforce/__version__.py
+++ b/simple_salesforce/__version__.py
@@ -5,7 +5,7 @@ This file shamelessly taken from the requests library"""
 __title__ = 'simple-salesforce'
 __description__ = 'A basic Salesforce.com REST API client.'
 __url__ = 'https://github.com/simple-salesforce/simple-salesforce'
-__version__ = '1.12.1a2'
+__version__ = '1.12.2b2'
 __author__ = 'Nick Catalano'
 __author_email__ = 'nickcatal@gmail.com'
 __license__ = 'Apache 2.0'

--- a/simple_salesforce/aio/aio_util.py
+++ b/simple_salesforce/aio/aio_util.py
@@ -1,32 +1,61 @@
 """Utility functions for simple-salesforce async calls"""
-from typing import Dict, Optional
+from functools import partial
+from typing import Callable, Dict, Optional
 
 import httpx
 
 from simple_salesforce.util import exception_handler
 
 
+def create_session_factory(
+    proxies=None, timeout: Optional[int] = None
+) -> Callable[[], httpx.AsyncClient]:
+    """
+    Convenience function for repeatedly returning the properly constructed
+    AsyncClient.
+    """
+    if proxies and timeout:
+        return partial(
+            httpx.AsyncClient,
+            proxies=proxies,
+            timeout=timeout
+        )
+    elif proxies:
+        return partial(
+            httpx.AsyncClient,
+            proxies=proxies
+        )
+    elif timeout:
+        return partial(
+            httpx.AsyncClient,
+            timeout=timeout
+        )
+
+    return partial(httpx.AsyncClient)
+
+
 async def call_salesforce(
     url: str = "",
     method: str = "GET",
-    async_client: Optional[httpx.AsyncClient] = None,
     headers: Optional[Dict] = None,
+    session_factory: Optional[Callable[[], httpx.AsyncClient]] = None,
     **kwargs
 ):
     """Utility method for performing HTTP call to Salesforce.
 
     Returns a `httpx.Response` object.
     """
-    if not async_client:
-        async_client = httpx.AsyncClient()
+    if session_factory:
+        client = session_factory()
+    else:
+        client = httpx.AsyncClient()
 
     headers = headers or dict()
     additional_headers = kwargs.pop("additional_headers", dict())
     headers.update(additional_headers or dict())
-    result = await async_client.request(method, url, headers=headers, **kwargs)
+    async with client as session:
+        result = await session.request(method, url, headers=headers, **kwargs)
     if result.status_code >= 300:
         exception_handler(result)
-    if not async_client:
-        await async_client.aclose()
 
     return result

--- a/simple_salesforce/aio/metadata.py
+++ b/simple_salesforce/aio/metadata.py
@@ -211,16 +211,16 @@ class AsyncSfdcMetadataApi:
 
     # pylint: disable=R0913
     def __init__(
-        self, session, session_id, instance, metadata_url, headers, api_version
+        self, session_id, instance, metadata_url, headers, api_version, session_factory=None
     ):
         """ Initialize and check session """
-        self.session = session
         self._session_id = session_id
         self._instance = instance
         self.metadata_url = metadata_url
         self.headers = headers
         self._api_version = api_version
         self._deploy_zip = None
+        self.session_factory = session_factory
 
         wsdl_path = os.path.join(
             os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
@@ -338,7 +338,7 @@ class AsyncSfdcMetadataApi:
         result = await call_salesforce(
             url=self.metadata_url + "deployRequest",
             method="POST",
-            session=self.session,
+            session_factory=self.session_factory,
             headers=self.headers,
             additional_headers=headers,
             data=request,
@@ -406,7 +406,7 @@ class AsyncSfdcMetadataApi:
         res = await call_salesforce(
             url=self.metadata_url + "deployRequest/" + async_process_id,
             method="POST",
-            session=self.session,
+            session_factory=self.session_factory,
             headers=self.headers,
             additional_headers=headers,
             data=mt_request,
@@ -564,7 +564,7 @@ class AsyncSfdcMetadataApi:
         res = await call_salesforce(
             url=self.metadata_url + "deployRequest/" + async_process_id,
             method="POST",
-            session=self.session,
+            session_factory=self.session_factory,
             headers=self.headers,
             additional_headers=headers,
             data=request,
@@ -603,7 +603,7 @@ class AsyncSfdcMetadataApi:
         res = await call_salesforce(
             url=self.metadata_url + "deployRequest/" + async_process_id,
             method="POST",
-            session=self.session,
+            session_factory=self.session_factory,
             headers=self.headers,
             additional_headers=headers,
             data=mt_request,

--- a/simple_salesforce/tests/test_aio/conftest.py
+++ b/simple_salesforce/tests/test_aio/conftest.py
@@ -184,6 +184,10 @@ def sf_client(constants, mock_httpx_client):
     client = AsyncSalesforce(
         session_id=constants["SESSION_ID"], proxies=constants["PROXIES"]
     )
+    async def refresh():
+        return constants["SESSION_ID"], "test"
+    client.login_refresh = refresh
+
     client.headers = {}
     client.base_url = "https://localhost/"
     client.metadata_url = "https://localhost/metadata/"

--- a/simple_salesforce/tests/test_aio/conftest.py
+++ b/simple_salesforce/tests/test_aio/conftest.py
@@ -182,12 +182,12 @@ def mock_httpx_client(monkeypatch):
 def sf_client(constants, mock_httpx_client):
     """Simple fixture for crafting the client used below"""
     client = AsyncSalesforce(
-        session_id=constants["SESSION_ID"], proxies=constants["PROXIES"]
+        session_factory=lambda: mock_httpx_client[1],
+        session_id=constants["SESSION_ID"],
+        proxies=constants["PROXIES"]
     )
-    async def refresh():
-        return constants["SESSION_ID"], "test"
-    client.login_refresh = refresh
 
+    client.login_refresh = mock.AsyncMock(return_value=(constants["SESSION_ID"], "test"))
     client.headers = {}
     client.base_url = "https://localhost/"
     client.metadata_url = "https://localhost/metadata/"

--- a/simple_salesforce/tests/test_aio/test_login.py
+++ b/simple_salesforce/tests/test_aio/test_login.py
@@ -25,7 +25,6 @@ async def test_default_domain_success(constants, mock_httpx_client):
     mock_client.custom_session_attrib = "X-1-2-3"
 
     (session_id, instance_url) = await AsyncSalesforceLogin(
-        session=mock_client,
         username="foo@bar.com",
         password="password",
         security_token="token",
@@ -49,7 +48,6 @@ async def test_custom_domain_success(constants, mock_httpx_client):
     mock_client.custom_session_attrib = "X-1-2-3"
 
     (session_id, instance_url) = await AsyncSalesforceLogin(
-        session=mock_client,
         username="foo@bar.com",
         password="password",
         domain="testdomain.my",
@@ -92,7 +90,6 @@ async def test_failure(mock_httpx_client):
 
     with pytest.raises(SalesforceAuthenticationFailed):
         await AsyncSalesforceLogin(
-            session=mock_client,
             username="foo@bar.com",
             password="password",
             security_token="token",
@@ -130,7 +127,6 @@ async def test_token_login_success_with_key_file(
     inner(happy_result)
 
     (session_id, instance_url) = await AsyncSalesforceLogin(
-        session=mock_client,
         username="foo@bar.com",
         consumer_key="12345.abcde",
         privatekey_file=sample_key_filepath,
@@ -157,7 +153,6 @@ async def test_token_login_success_with_key_string(
     )
     inner(happy_result)
     (session_id, instance_url) = await AsyncSalesforceLogin(
-        session=mock_client,
         username="foo@bar.com",
         consumer_key="12345.abcde",
         privatekey=sample_key.decode(),
@@ -185,7 +180,6 @@ async def test_token_login_success_with_key_bytes(
     )
     inner(happy_result)
     (session_id, instance_url) = await AsyncSalesforceLogin(
-        session=mock_client,
         username="foo@bar.com",
         consumer_key="12345.abcde",
         privatekey=sample_key,
@@ -220,7 +214,6 @@ async def test_token_login_failure(mock_httpx_client, sample_key_filepath):
 
     with pytest.raises(SalesforceAuthenticationFailed):
         await AsyncSalesforceLogin(
-            session=mock_client,
             username="foo@bar.com",
             consumer_key="12345.abcde",
             privatekey_file=sample_key_filepath,
@@ -255,7 +248,6 @@ async def test_token_login_failure_with_warning(
     with warnings.catch_warnings(record=True) as warning:
         with pytest.raises(SalesforceAuthenticationFailed):
             await AsyncSalesforceLogin(
-                session=mock_client,
                 username="foo@bar.com",
                 consumer_key="12345.abcde",
                 privatekey_file=sample_key_filepath,

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,5 +1,6 @@
 pylint
 coverage
+cryptography
 pytest
 pytest-asyncio
 pytest-coverage


### PR DESCRIPTION
This PR includes changes from upstream adapted into the `aio` package. As always, this PR works hard to maintain compatibility upstream, copying as much as possible the strategies and design used there. The goal here is to make it as easy as possible for upstream maintainers to read and contribute to the `aio` package and it is thought that by making the code explicitly duplicate upstream, we can enable that.

In addition, as the `aio` package is meant to be stand-alone, we have _duplicated_ functionality instead of trying to build shared functions that both upstream `simple-salesforce` and `aio` can use. This is meant to allow people uninterested in the `aio` package to continue ignoring it.

Changes in this PR include the following:

- `OrderedDict` can be overridden for `AsyncSalesforce` and `AsyncSFType` results with `object_pairs_hook` kwarg
- JSON float parsing default can be overridden for `AsyncSalesforce` and `AsyncSFType` results with `parse_float` kwarg
- Removed error-prone internal `httpx.AsyncClient` management: closing sessions after each request now.
- Added `base64` methods from `api.py` module to `AsyncSFType` class.
- Ability to refresh authorized sessions is now included in the `AsyncSalesforce` client via a partially-applied function. In addition, we have added automatic retries for requests that receive a `401` response.
- Add basic support for httpx timeouts.
- New `AsyncMetadataType`, inspired by upstream
- Bulk operations batch size is respects V1 batch (adapted from upstream).
- More tests added; test coverage improved